### PR TITLE
Build Haddock documentation in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,9 +11,14 @@ dependencies:
     - sudo apt-get install -y stack
   override:
     - stack --no-terminal setup
-    - stack --no-terminal build --test --only-dependencies -j1
+    - stack --no-terminal build --haddock --test --only-dependencies -j1
 
 test:
   override:
     - stack --no-terminal build --test
     - stack --no-terminal test
+    - stack --no-terminal haddock
+
+general:
+  artifacts:
+    - .stack-work/dist/x86_64-linux/Cabal-1.24.0.0/doc/html/graphql-api

--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,5 @@ test:
     - stack --no-terminal build --test
     - stack --no-terminal test
     - stack --no-terminal haddock
-
-general:
-  artifacts:
-    - .stack-work/dist/x86_64-linux/Cabal-1.24.0.0/doc/html/graphql-api
+  post:
+    - mv .stack-work/dist/x86_64-linux/Cabal-1.24.0.0/doc/html/graphql-api $CIRCLE_ARTIFACTS/


### PR DESCRIPTION
Fixes #12

If you go to the [Artifacts tab of the build page](https://circleci.com/gh/jml/graphql-api/29#artifacts/containers/0) you can see a link to the [generated haddock documentation](https://29-70682597-gh.circle-artifacts.com/0/tmp/circle-artifacts.zgAfleG/graphql-api/index.html). 

It's worth having a poke around, because it's almost immediately obvious that:
- we need more docs :smiley_cat: 
- our module structure isn't super obvious to newcomers (or even to me!)
