### PR TITLE
Explicit export list for definitions

### DIFF
--- a/src/GraphQL/Definitions.hs
+++ b/src/GraphQL/Definitions.hs
@@ -16,7 +16,6 @@ module GraphQL.Definitions
   , GraphQLEnum(..)
   , Interface
   , (:>)(..)
-  , (:<>)(..)
   , (:<|>)(..)
   -- | Exported for testing. Perhaps should be a different module.
   , getFieldDefinition
@@ -61,10 +60,6 @@ import qualified Data.GraphQL.AST as AST
 -- @
 data a :> b = a :> b
 infixr 8 :>
-
--- | Object field separation operator.
-data a :<> b = a :<> b
-infixr 8 :<>
 
 -- | Union type separation operator.
 data a :<|> b = a :<|> b

--- a/src/GraphQL/Definitions.hs
+++ b/src/GraphQL/Definitions.hs
@@ -35,7 +35,30 @@ import qualified GHC.TypeLits (TypeError, ErrorMessage(..))
 import qualified GraphQL.Value as GValue
 import qualified Data.GraphQL.AST as AST
 
--- | Argument operator. Can only be used with Field.
+-- $setup
+-- >>> :set -XDataKinds -XTypeOperators
+
+-- | Argument operator. Can only be used with 'Field'.
+--
+-- Say we have a @@Company@@ object that has a field that shows whether
+-- someone is an employee, e.g.
+--
+-- @
+--   type Company {
+--     hasEmployee(employeeName: String!): String!
+--   }
+-- @
+--
+-- Then we might represent that as:
+--
+-- >>> type Company = Object "Company" '[] '[Argument "employeeName" GValue.String :> Field "hasEmployee" Bool]
+--
+-- For multiple arguments, simply chain them together with @@:>@@, ending finally with 'Field'.
+-- e.g.
+--
+-- @
+--   Argument "foo" String :> Argument "bar" Int :> Field "qux" Int
+-- @
 data a :> b = a :> b
 infixr 8 :>
 

--- a/src/GraphQL/Definitions.hs
+++ b/src/GraphQL/Definitions.hs
@@ -39,7 +39,7 @@ import qualified Data.GraphQL.AST as AST
 
 -- | Argument operator. Can only be used with 'Field'.
 --
--- Say we have a @@Company@@ object that has a field that shows whether
+-- Say we have a @Company@ object that has a field that shows whether
 -- someone is an employee, e.g.
 --
 -- @
@@ -50,10 +50,10 @@ import qualified Data.GraphQL.AST as AST
 --
 -- Then we might represent that as:
 --
--- >>> type Company = Object "Company" '[] '[Argument "employeeName" GValue.String :> Field "hasEmployee" Bool]
+-- >>> type Company = Object "Company" '[] '[Argument "employeeName" Text :> Field "hasEmployee" Bool]
 --
--- For multiple arguments, simply chain them together with @@:>@@, ending finally with 'Field'.
--- e.g.
+-- For multiple arguments, simply chain them together with ':>', ending
+-- finally with 'Field'. e.g.
 --
 -- @
 --   Argument "foo" String :> Argument "bar" Int :> Field "qux" Int

--- a/src/GraphQL/Definitions.hs
+++ b/src/GraphQL/Definitions.hs
@@ -5,8 +5,26 @@
 {-# LANGUAGE OverloadedLabels, MagicHash #-}
 
 -- | Type-level definitions for a GraphQL schema.
-module GraphQL.Definitions where
--- TODO export list
+module GraphQL.Definitions
+  ( Object
+  , Field
+  , Argument
+  , DefaultArgument
+  , Union
+  , List
+  , Enum
+  , GraphQLEnum(..)
+  , Interface
+  , (:>)(..)
+  , (:<>)(..)
+  , (:<|>)(..)
+  -- | Exported for testing. Perhaps should be a different module.
+  , getFieldDefinition
+  , getDefinition
+  , getInterfaceDefinition
+  , getAnnotatedType
+  , getAnnotatedInputType
+  ) where
 
 import Protolude hiding (Enum)
 

--- a/src/GraphQL/TypeApi.hs
+++ b/src/GraphQL/TypeApi.hs
@@ -12,6 +12,7 @@
 module GraphQL.TypeApi
   ( QueryError(..) -- XXX: Exporting constructor for tests. Not sure if that's what we really want.
   , HasGraph(..)
+  , (:<>)(..)
   , ReadValue(..)
   , BuildFieldResolver(..)
   ) where
@@ -46,6 +47,27 @@ instance Exception QueryError
 queryError :: forall m a. MonadThrow m => Text -> m a
 queryError = throwM . QueryError
 
+-- | Object field separation operator.
+--
+-- Use this to provide handlers for fields of an object.
+--
+-- Say you had an object with \"foo\" and \"bar\" fields, e.g.
+--
+-- @
+--   type MyObject {
+--     foo: Int!
+--     bar: String!
+--   }
+-- @
+--
+-- >>> :m +System.Environment
+-- >>> let fooHandler = pure 42
+-- >>> let barHandler = System.Environment.getProgName
+-- >>> let myObjectHandler = pure $ fooHandler :<> barHandler :<> ()
+--
+-- :}
+data a :<> b = a :<> b
+infixr 8 :<>
 
 -- TODO instead of SelectionSet we want something like
 -- NormalizedSelectionSet which has query fragments etc. resolved.

--- a/src/GraphQL/TypeApi.hs
+++ b/src/GraphQL/TypeApi.hs
@@ -51,7 +51,8 @@ queryError = throwM . QueryError
 --
 -- Use this to provide handlers for fields of an object.
 --
--- Say you had an object with \"foo\" and \"bar\" fields, e.g.
+-- Say you had the following GraphQL type with \"foo\" and \"bar\" fields,
+-- e.g.
 --
 -- @
 --   type MyObject {
@@ -60,12 +61,12 @@ queryError = throwM . QueryError
 --   }
 -- @
 --
+-- You could provide handlers for it like this:
+--
 -- >>> :m +System.Environment
 -- >>> let fooHandler = pure 42
 -- >>> let barHandler = System.Environment.getProgName
 -- >>> let myObjectHandler = pure $ fooHandler :<> barHandler :<> ()
---
--- :}
 data a :<> b = a :<> b
 infixr 8 :<>
 

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -3,12 +3,14 @@
 module Examples.UnionExample  where
 
 import Protolude hiding (Enum)
+
+import qualified Data.GraphQL.AST as AST
+import Data.Attoparsec.Text (parseOnly, endOfInput)
+import Data.GraphQL.Parser (document)
+
 import GraphQL.Definitions
 import GraphQL.TypeApi
-import qualified Data.GraphQL.AST as AST
-import Data.GraphQL.Parser (document)
 import GraphQL.Value (Value)
-import Data.Attoparsec.Text (parseOnly, endOfInput)
 
 type O1 = Object "O1" '[] '[Field "o1" Text]
 type O2 = Object "O2" '[] '[Field "o2" Text]

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -7,7 +7,17 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import GraphQL.Definitions
+  ( Object
+  , Field
+  , Argument
+  , (:>)
+  , (:<>)(..)
+  )
 import GraphQL.TypeApi
+  ( HandlerType
+  , QueryError(..)
+  , buildResolver
+  )
 import qualified Data.GraphQL.AST as AST
 import Data.Aeson (encode)
 

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -11,12 +11,12 @@ import GraphQL.Definitions
   , Field
   , Argument
   , (:>)
-  , (:<>)(..)
   )
 import GraphQL.TypeApi
   ( HandlerType
   , QueryError(..)
   , buildResolver
+  , (:<>)(..)
   )
 import qualified Data.GraphQL.AST as AST
 import Data.Aeson (encode)

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -7,7 +7,38 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import GraphQL.Definitions
+  ( GraphQLEnum(..)
+  , Enum
+  , Object
+  , Field
+  , Argument
+  , Interface
+  , Union
+  , List
+  , (:>)
+  , getAnnotatedType
+  , getAnnotatedInputType
+  , getDefinition
+  , getFieldDefinition
+  , getInterfaceDefinition
+  )
 import GraphQL.Schema
+  ( EnumTypeDefinition(..)
+  , EnumValueDefinition(..)
+  , FieldDefinition(..)
+  , ObjectTypeDefinition(..)
+  , NonEmptyList(..)
+  , InterfaceTypeDefinition(..)
+  , AnnotatedType(..)
+  , ListType(..)
+  , UnionTypeDefinition(..)
+  , Type(..)
+  , TypeDefinition(..)
+  , NonNullType(..)
+  , Name(..)
+  , Builtin(..)
+  , InputType(..)
+  )
 
 -- Examples taken from the spec
 
@@ -64,40 +95,38 @@ tests :: IO TestTree
 tests = testSpec "Type" $ do
   describe "Field" $
     it "encodes correctly" $ do
-    getFieldDefinition @(Field "hello" Int) `shouldBe` (FieldDefinition (Name "hello") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GInt))))
+    getFieldDefinition @(Field "hello" Int) `shouldBe` FieldDefinition (Name "hello") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GInt)))
   describe "Interface" $
     it "encodes correctly" $ do
-    getInterfaceDefinition @Sentient `shouldBe` (
+    getInterfaceDefinition @Sentient `shouldBe`
       InterfaceTypeDefinition
         (Name "Sentient")
         (NonEmptyList [FieldDefinition (Name "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
-      )
   describe "full example" $
     it "encodes correctly" $ do
-    getDefinition @Human `shouldBe` (
+    getDefinition @Human `shouldBe`
       ObjectTypeDefinition (Name "Human")
         [ InterfaceTypeDefinition (Name "Sentient") (
             NonEmptyList [FieldDefinition (Name "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
         ]
         (NonEmptyList [FieldDefinition (Name "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
-      )
   describe "output Enum" $
     it "encodes correctly" $ do
-    getAnnotatedType @DogCommand `shouldBe` (
+    getAnnotatedType @DogCommand `shouldBe`
        TypeNonNull (NonNullTypeNamed (DefinedType (TypeDefinitionEnum (EnumTypeDefinition (Name "DogCommand")
          [ EnumValueDefinition (Name "SIT")
          , EnumValueDefinition (Name "DOWN")
          , EnumValueDefinition (Name "HEEL")
-         ])))))
+         ]))))
   describe "Union type" $
     it "encodes correctly" $ do
-    getAnnotatedType @CatOrDog `shouldBe` (
+    getAnnotatedType @CatOrDog `shouldBe`
       TypeNamed (DefinedType (TypeDefinitionUnion (UnionTypeDefinition (Name "CatOrDog")
         (NonEmptyList [ getDefinition @Cat
                       , getDefinition @Dog
                       ]
-        )))))
+        ))))
   describe "List" $
     it "encodes correctly" $ do
-    getAnnotatedType @(List Int) `shouldBe` (TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinType GInt)))))
-    getAnnotatedInputType @(List Int) `shouldBe` (TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinInputType GInt)))))
+    getAnnotatedType @(List Int) `shouldBe` TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinType GInt))))
+    getAnnotatedInputType @(List Int) `shouldBe` TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinInputType GInt))))


### PR DESCRIPTION
Also,

* remove some redundant parens
* copious doc comments for `(:<>)` and `(:>)`
* move `(:<>)` to typeapi