### PR TITLE
Move Name to Value module and make invalid Objects impossible

### DIFF
--- a/HLint.hs
+++ b/HLint.hs
@@ -1,0 +1,5 @@
+import "hint" HLint.HLint
+import "hint" HLint.Generalise
+
+ignore "Use fmap"
+ignore "Redundant do"

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -64,6 +64,7 @@ test-suite graphql-api-doctests
       TypeApiTests
       TypeTests
       ValidationTests
+      ValueTests
   default-language: Haskell2010
 
 test-suite graphql-api-tests
@@ -91,4 +92,5 @@ test-suite graphql-api-tests
       TypeApiTests
       TypeTests
       ValidationTests
+      ValueTests
   default-language: Haskell2010

--- a/src/GraphQL/Output.hs
+++ b/src/GraphQL/Output.hs
@@ -9,7 +9,7 @@ module GraphQL.Output
 
 import Protolude hiding (Location, Map)
 import Data.List.NonEmpty (NonEmpty)
-import GraphQL.Value (Object, objectFromList, ToValue(..), Value(ValueNull))
+import GraphQL.Value (Object, Name, objectFromList, ToValue(..), Value(ValueObject, ValueNull))
 
 -- | GraphQL response.
 --
@@ -45,30 +45,39 @@ data Response
   | PartialSuccess Object Errors
   deriving (Eq, Ord, Show)
 
+-- | Construct an object from a list of names and values.
+--
+-- Panic if there are duplicate names.
+unsafeMakeObject :: [(Name, Value)] -> Value
+unsafeMakeObject fields =
+  case objectFromList fields of
+    Nothing -> panic $ "Object has duplicate keys: " <> show fields
+    Just object -> ValueObject object
+
 instance ToValue Response where
-  toValue (Success x) = toValue (objectFromList [("data", toValue x)])
-  toValue (PreExecutionFailure e) = toValue (objectFromList [("errors", toValue e)])
-  toValue (ExecutionFailure e) = toValue (objectFromList [("data", ValueNull)
-                                                         ,("errors", toValue e)
-                                                         ])
-  toValue (PartialSuccess x e) = toValue (objectFromList [("data", toValue x)
-                                                         ,("errors", toValue e)
-                                                         ])
+  toValue (Success x) = unsafeMakeObject [("data", toValue x)]
+  toValue (PreExecutionFailure e) = unsafeMakeObject [("errors", toValue e)]
+  toValue (ExecutionFailure e) = unsafeMakeObject [("data", ValueNull)
+                                                  ,("errors", toValue e)]
+  toValue (PartialSuccess x e) = unsafeMakeObject [("data", toValue x)
+                                                  ,("errors", toValue e)
+                                                  ]
 
 type Errors = NonEmpty Error
 
 data Error = Error Text [Location] deriving (Eq, Ord, Show)
 
 instance ToValue Error where
-  toValue (Error message []) = toValue (objectFromList [("message", toValue message)])
-  toValue (Error message locations) = toValue (objectFromList [("message", toValue message)
-                                                              ,("locations", toValue locations)
-                                                              ])
+  toValue (Error message []) = unsafeMakeObject [("message", toValue message)]
+  toValue (Error message locations) = unsafeMakeObject [("message", toValue message)
+                                                       ,("locations", toValue locations)
+                                                       ]
 
 data Location = Location Line Column deriving (Eq, Ord, Show)
 type Line = Int32  -- XXX: 1-indexed natural number
 type Column = Int32  -- XXX: 1-indexed natural number
 
 instance ToValue Location where
-  toValue (Location line column) = toValue (objectFromList [("line" , toValue line)
-                                                           ,("column", toValue column)])
+  toValue (Location line column) = unsafeMakeObject [("line" , toValue line)
+                                                    ,("column", toValue column)
+                                                    ]

--- a/src/GraphQL/Output.hs
+++ b/src/GraphQL/Output.hs
@@ -9,7 +9,7 @@ module GraphQL.Output
 
 import Protolude hiding (Location, Map)
 import Data.List.NonEmpty (NonEmpty)
-import GraphQL.Value (Map, mapFromList, ToValue(..), Value(ValueNull))
+import GraphQL.Value (Object, objectFromList, ToValue(..), Value(ValueNull))
 
 -- | GraphQL response.
 --
@@ -39,36 +39,36 @@ import GraphQL.Value (Map, mapFromList, ToValue(..), Value(ValueNull))
 --     with list of locations
 --   * locations are maps with 1-indexed "line" and "column" keys.
 data Response
-  = Success Map
+  = Success Object
   | PreExecutionFailure Errors
   | ExecutionFailure Errors
-  | PartialSuccess Map Errors
+  | PartialSuccess Object Errors
   deriving (Eq, Ord, Show)
 
 instance ToValue Response where
-  toValue (Success x) = toValue (mapFromList [("data", toValue x)])
-  toValue (PreExecutionFailure e) = toValue (mapFromList [("errors", toValue e)])
-  toValue (ExecutionFailure e) = toValue (mapFromList [("data", ValueNull)
-                                                      ,("errors", toValue e)
-                                                      ])
-  toValue (PartialSuccess x e) = toValue (mapFromList [("data", toValue x)
-                                                      ,("errors", toValue e)
-                                                      ])
+  toValue (Success x) = toValue (objectFromList [("data", toValue x)])
+  toValue (PreExecutionFailure e) = toValue (objectFromList [("errors", toValue e)])
+  toValue (ExecutionFailure e) = toValue (objectFromList [("data", ValueNull)
+                                                         ,("errors", toValue e)
+                                                         ])
+  toValue (PartialSuccess x e) = toValue (objectFromList [("data", toValue x)
+                                                         ,("errors", toValue e)
+                                                         ])
 
 type Errors = NonEmpty Error
 
 data Error = Error Text [Location] deriving (Eq, Ord, Show)
 
 instance ToValue Error where
-  toValue (Error message []) = toValue (mapFromList [("message", toValue message)])
-  toValue (Error message locations) = toValue (mapFromList [("message", toValue message)
-                                                           ,("locations", toValue locations)
-                                                           ])
+  toValue (Error message []) = toValue (objectFromList [("message", toValue message)])
+  toValue (Error message locations) = toValue (objectFromList [("message", toValue message)
+                                                              ,("locations", toValue locations)
+                                                              ])
 
 data Location = Location Line Column deriving (Eq, Ord, Show)
 type Line = Int32  -- XXX: 1-indexed natural number
 type Column = Int32  -- XXX: 1-indexed natural number
 
 instance ToValue Location where
-  toValue (Location line column) = toValue (mapFromList [("line" , toValue line)
-                                                        ,("column", toValue column)])
+  toValue (Location line column) = toValue (objectFromList [("line" , toValue line)
+                                                           ,("column", toValue column)])

--- a/src/GraphQL/Schema.hs
+++ b/src/GraphQL/Schema.hs
@@ -34,12 +34,7 @@ module GraphQL.Schema
 
 import Protolude hiding (Type)
 
-import GraphQL.Value (Value)
-
--- | A name in GraphQL.
---
--- https://facebook.github.io/graphql/#sec-Names
-newtype Name = Name Text deriving (Eq, Show, IsString) -- XXX: Phantom type?
+import GraphQL.Value (Name(..), Value)
 
 -- XXX: Use the built-in NonEmptyList in Haskell
 newtype NonEmptyList a = NonEmptyList [a] deriving (Eq, Show)
@@ -49,7 +44,7 @@ data AnnotatedType t = TypeNamed t
                      | TypeNonNull (NonNullType t)
                      deriving (Eq,Show)
 
-data ListType t = ListType (AnnotatedType t) deriving (Eq, Show)
+newtype ListType t = ListType (AnnotatedType t) deriving (Eq, Show)
 
 data NonNullType t = NonNullTypeNamed t
                    | NonNullTypeList  (ListType t)
@@ -83,8 +78,8 @@ data InterfaceTypeDefinition = InterfaceTypeDefinition Name (NonEmptyList FieldD
 data UnionTypeDefinition = UnionTypeDefinition Name (NonEmptyList ObjectTypeDefinition)
                            deriving (Eq, Show)
 
-data ScalarTypeDefinition = ScalarTypeDefinition Name
-                            deriving (Eq, Show)
+newtype ScalarTypeDefinition = ScalarTypeDefinition Name
+                             deriving (Eq, Show)
 
 -- | Types that are built into GraphQL.
 --

--- a/src/GraphQL/TypeApi.hs
+++ b/src/GraphQL/TypeApi.hs
@@ -159,7 +159,7 @@ instance forall v. ReadValue v => ReadValue [v] where
 
 instance forall v. ReadValue v => ReadValue (Maybe v) where
   valueMissing _ = pure Nothing
-  readValue v = map Just (readValue v)
+  readValue v = map Just (readValue @v v)
 
 -- TODO: variables should error, they should have been resolved already.
 --
@@ -282,7 +282,7 @@ instance forall m typeName interfaces fields rest.
         result <- buildResolver @m @(Object typeName interfaces fields) lh subSelection
         -- TODO: See if we can prevent this from happening at compile time.
         case GValue.toObject result of
-          Nothing -> queryError $ "Expected object as result of union query: " <> show result
+          Nothing -> panic $ "Expected object as result of union query: " <> show result
           Just object -> pure object
     | otherwise = runUnion @m @rest rh fragment
     where typeName = toS (symbolVal (Proxy :: Proxy typeName))

--- a/src/GraphQL/TypeApi.hs
+++ b/src/GraphQL/TypeApi.hs
@@ -252,7 +252,7 @@ instance forall typeName interfaces fields m.
     -- We're evaluating an Object so we're collecting (name, Value)
     -- pairs from runFields and build a GValue.Map with them.
     r <- forM selectionSet $ \selection -> runFields @m @fields handler selection
-    pure $ GValue.toValue (GValue.mapFromList r)
+    pure $ GValue.toValue (GValue.objectFromList r)
 
 
 -- | Closed type family to enforce the invariant that Union types
@@ -299,7 +299,7 @@ instance forall m ks ru.
   buildResolver handler selection = do
     -- GraphQL invariant is that all items in a Union must be objects
     -- which means 1) they have fields 2) They are ValueMap
-    values <- map GValue.unionMap (traverse (runUnion @m @ru handler) selection)
+    values <- map GValue.unionObject (traverse (runUnion @m @ru handler) selection)
     case values of
       Left _ -> panic "It looks like you used a non-Object type in a Union"
       Right ok -> pure ok

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -4,14 +4,13 @@
 -- | Literal GraphQL values.
 module GraphQL.Value
   (
-    -- | GraphQL values
-    GraphQL.Value.Value(..)
+    Value(..)
   , ToValue(..)
   , Name
   , List
   , Map
-  , String
   , mapFromList
+  , String
   , unionMap
   ) where
 
@@ -52,7 +51,7 @@ newtype String = String Text deriving (Eq, Ord, Show)
 instance ToJSON String where
   toJSON (String x) = toJSON x
 
-newtype List = List [GraphQL.Value.Value] deriving (Eq, Ord, Show)
+newtype List = List [Value] deriving (Eq, Ord, Show)
 
 makeList :: (Functor f, Foldable f, ToValue a) => f a -> List
 makeList = List . toList . map toValue
@@ -65,10 +64,9 @@ instance ToJSON List where
 -- XXX: GraphQL spec itself sometimes says 'map' and other times 'object', but
 -- jml hasn't read 100% clearly. Let's find something and stick to it, and
 -- make sure that there isn't a real distinction between to the two.
-newtype Map = Map [(Name,  GraphQL.Value.Value)] deriving (Eq, Ord, Show, Monoid)
+newtype Map = Map [(Name, Value)] deriving (Eq, Ord, Show, Monoid)
 
-
-mapFromList :: [(Name,  GraphQL.Value.Value)] -> Map
+mapFromList :: [(Name, Value)] -> Map
 mapFromList = Map
 
 -- TODO this would be nicer with a prism `_ValueMap` but don't want to
@@ -88,9 +86,9 @@ instance ToJSON Map where
 
 -- | Turn a Haskell value into a GraphQL value.
 class ToValue a where
-  toValue :: a -> GraphQL.Value.Value
+  toValue :: a -> Value
 
-instance ToValue GraphQL.Value.Value where
+instance ToValue Value where
   toValue = identity
 
 -- XXX: Should this just be for Foldable?

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -66,6 +66,8 @@ instance ToJSON List where
 -- \"Maps\", but everywhere else in the spec refers to them as objects.
 newtype Object = Object [ObjectField] deriving (Eq, Ord, Show, Monoid)
 
+-- TODO: Property test for object that shows that Names are unique.
+
 data ObjectField = ObjectField Name Value deriving (Eq, Ord, Show)
 
 objectFromList :: [(Name, Value)] -> Object

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -73,6 +73,8 @@ objectFromList = Object . map (uncurry ObjectField)
 
 -- TODO this would be nicer with a prism `_ValueMap` but don't want to
 -- pull in lens as dependency.
+-- TODO: actually figure out what the hell this is supposed to do.
+-- TODO: Since there's only one failure, should probably be Maybe.
 unionObject :: [Value] -> Either Text Value
 unionObject values = map (ValueObject . fold) (traverse isValueMap values)
   where

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -74,17 +74,17 @@ mapFromList = Map
 -- TODO this would be nicer with a prism `_ValueMap` but don't want to
 -- pull in lens as dependency.
 unionMap :: [Value] -> Either Text Value
-unionMap values = map (ValueMap . fold)  (sequence (map isValueMap values))
+unionMap values = map (ValueMap . fold) (traverse isValueMap values)
   where
     isValueMap = \case
-      (ValueMap m) -> Right m
+      ValueMap m -> Right m
       _ -> Left "non-ValueMap member"
 
 
 instance ToJSON Map where
   -- Direct encoding to preserve order of keys / values
   toJSON (Map xs) = toJSON (Map.fromList xs)
-  toEncoding (Map xs) = pairs (fold (map (\(k, v) -> (toS k) .= v) xs))
+  toEncoding (Map xs) = pairs (fold (map (\(k, v) -> toS k .= v) xs))
 
 -- | Turn a Haskell value into a GraphQL value.
 class ToValue a where

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -99,7 +99,7 @@ objectFromList :: [(Name, Value)] -> Maybe Object
 objectFromList = makeObject . map (uncurry ObjectField)
 
 unionObjects :: [Object] -> Maybe Object
-unionObjects = makeObject . (=<<) objectFields
+unionObjects objects = makeObject (objects >>= objectFields)
 
 instance ToJSON Object where
   -- Direct encoding to preserve order of keys / values

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -6,17 +6,22 @@ import Protolude
 
 import Test.Tasty (defaultMain, testGroup)
 
-import qualified ValidationTests
-import qualified TypeTests
 import qualified TypeApiTests
+import qualified TypeTests
+import qualified ValidationTests
+import qualified ValueTests
 
 -- import examples to ensure they compile
 import Examples.UnionExample ()
 
 main :: IO ()
 main = do
-  t <- sequence [ ValidationTests.tests
-                , TypeTests.tests
-                , TypeApiTests.tests
-                ]
-  defaultMain (testGroup "spec" t)
+  t <- sequence tests
+  defaultMain . testGroup "spec" $ t
+  where
+    tests =
+      [ TypeApiTests.tests
+      , TypeTests.tests
+      , ValidationTests.tests
+      , ValueTests.tests
+      ]

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -17,7 +17,7 @@ import Examples.UnionExample ()
 main :: IO ()
 main = do
   t <- sequence tests
-  defaultMain . testGroup "spec" $ t
+  defaultMain . testGroup "GraphQL API" $ t
   where
     tests =
       [ TypeApiTests.tests

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -10,8 +10,8 @@ import qualified Data.GraphQL.AST as AST
 import GraphQL.Validation (ValidationError(..), getErrors)
 
 tests :: IO TestTree
-tests = testSpec "GraphQL API" $ do
-  describe "Validation" $ do
+tests = testSpec "Validation" $ do
+  describe "getErrors" $ do
     it "Treats simple queries as valid" $ do
       let doc = AST.Document
                 [ AST.DefinitionOperation

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -1,0 +1,14 @@
+module ValueTests (tests) where
+
+import Protolude
+
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
+
+import GraphQL.Value (unionObject, objectFromList, toValue)
+
+tests :: IO TestTree
+tests = testSpec "Value" $ do
+  describe "unionObject" $ do
+    it "returns empty on empty list" $ do
+      unionObject [] `shouldBe` Right (toValue (objectFromList []))

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeApplications #-}
 module ValueTests (tests) where
 
 import Protolude
@@ -12,3 +13,14 @@ tests = testSpec "Value" $ do
   describe "unionObject" $ do
     it "returns empty on empty list" $ do
       unionObject [] `shouldBe` Right (toValue (objectFromList []))
+    it "merges objects" $ do
+      let foo = toValue (objectFromList [("foo", toValue @Int32 1),("bar",toValue @Int32 2)])
+      let bar = toValue (objectFromList [("bar", toValue @Text "cow"),("baz",toValue @Int32 3)])
+      -- TODO: This is the *wrong* behaviour. Documenting it in a test now to
+      -- make it easier to talk about.
+      let expected = [ ("foo", toValue @Int32 1)
+                     , ("bar", toValue @Int32 2)
+                     , ("bar", toValue @Text "cow")
+                     , ("baz", toValue @Int32 3)
+                     ]
+      unionObject [foo,bar] `shouldBe` Right (toValue (objectFromList expected))

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -4,23 +4,41 @@ module ValueTests (tests) where
 import Protolude
 
 import Test.Tasty (TestTree)
-import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
+import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
 
-import GraphQL.Value (unionObject, objectFromList, toValue)
+import GraphQL.Value
+  ( Object(..)
+  , ObjectField(..)
+  , unionObjects
+  , objectFromList
+  , toValue
+  )
 
 tests :: IO TestTree
 tests = testSpec "Value" $ do
   describe "unionObject" $ do
     it "returns empty on empty list" $ do
-      unionObject [] `shouldBe` Right (toValue (objectFromList []))
+      unionObjects [] `shouldBe` objectFromList []
     it "merges objects" $ do
-      let foo = toValue (objectFromList [("foo", toValue @Int32 1),("bar",toValue @Int32 2)])
-      let bar = toValue (objectFromList [("bar", toValue @Text "cow"),("baz",toValue @Int32 3)])
-      -- TODO: This is the *wrong* behaviour. Documenting it in a test now to
-      -- make it easier to talk about.
-      let expected = [ ("foo", toValue @Int32 1)
-                     , ("bar", toValue @Int32 2)
-                     , ("bar", toValue @Text "cow")
-                     , ("baz", toValue @Int32 3)
-                     ]
-      unionObject [foo,bar] `shouldBe` Right (toValue (objectFromList expected))
+      let (Just foo) = objectFromList [("foo", toValue @Int32 1),("bar",toValue @Int32 2)]
+      let (Just bar) = objectFromList [("bar", toValue @Text "cow"),("baz",toValue @Int32 3)]
+      let observed = unionObjects [foo, bar]
+      observed `shouldBe` Nothing
+    it "merges objects with unique keys" $ do
+      let (Just foo) = objectFromList [("foo", toValue @Int32 1)]
+      let (Just bar) = objectFromList [("bar", toValue @Text "cow"),("baz",toValue @Int32 3)]
+      let (Just expected) = objectFromList [ ("foo", toValue @Int32 1)
+                                           , ("bar", toValue @Text "cow")
+                                           , ("baz", toValue @Int32 3)
+                                           ]
+      let (Just observed) = unionObjects [foo, bar]
+      observed `shouldBe` expected
+      expected `shouldSatisfy` prop_fieldsUnique
+
+
+-- | All of the fields in an object should have unique names.
+prop_fieldsUnique :: Object -> Bool
+prop_fieldsUnique object =
+  fieldNames == ordNub fieldNames
+  where
+    fieldNames = [name | ObjectField name _ <- objectFields object]


### PR DESCRIPTION
I started out moving `Name` to the `Value` module with the intent of not adding any new TODOs. I ended up adding three, with a much bigger PR than I expected.

That's because I tried to eliminate the TODO that asked `What the heck does unionObject do?` I wrote a test to figure it out and found that it constructed invalid objects--objects with duplicate field names. I really don't want to ever have that bug again, so I jotted down a property and updated the types to give `Object` smart constructors so it's now only possible to construct Objects with unique field names.

To be honest, I still don't understand why `unionObjects` is the right behaviour in the union resolver, but I'm certain that its old behaviour was definitely wrong.

* Start of tests for `GraphQL.Value`
* Remove duplication of `Name` from `Schema` and `Value`, moving everything to `Value`
* Create `ObjectField` type for object fields
* Rename `Map` to `Object`, as per the TODO comment and spec
* Change some `data` to `newtype` (hlint warning, removes runtime overhead)
* Remove unnecessary parens (hlint)
* Extract `wrongType` helper (we can have top-level private functions now that we have explicit export lists)
