### PR TITLE
Smart constructor for Name

### DIFF
--- a/src/GraphQL/Output.hs
+++ b/src/GraphQL/Output.hs
@@ -9,7 +9,13 @@ module GraphQL.Output
 
 import Protolude hiding (Location, Map)
 import Data.List.NonEmpty (NonEmpty)
-import GraphQL.Value (Object, Name, objectFromList, ToValue(..), Value(ValueObject, ValueNull))
+import GraphQL.Value
+  ( Object
+  , objectFromList
+  , unsafeMakeName
+  , ToValue(..)
+  , Value(ValueObject, ValueNull)
+  )
 
 -- | GraphQL response.
 --
@@ -48,9 +54,9 @@ data Response
 -- | Construct an object from a list of names and values.
 --
 -- Panic if there are duplicate names.
-unsafeMakeObject :: [(Name, Value)] -> Value
+unsafeMakeObject :: [(Text, Value)] -> Value
 unsafeMakeObject fields =
-  case objectFromList fields of
+  case objectFromList (map (first unsafeMakeName) fields) of
     Nothing -> panic $ "Object has duplicate keys: " <> show fields
     Just object -> ValueObject object
 

--- a/src/GraphQL/Schema.hs
+++ b/src/GraphQL/Schema.hs
@@ -13,7 +13,7 @@ module GraphQL.Schema
   , Builtin(..)
   -- * Defining new types
   , TypeDefinition(..)
-  , Name(..)
+  , Name
   , ArgumentDefinition(..)
   , EnumValueDefinition(..)
   , EnumTypeDefinition(..)
@@ -34,7 +34,7 @@ module GraphQL.Schema
 
 import Protolude hiding (Type)
 
-import GraphQL.Value (Name(..), Value)
+import GraphQL.Value (Name, Value)
 
 -- XXX: Use the built-in NonEmptyList in Haskell
 newtype NonEmptyList a = NonEmptyList [a] deriving (Eq, Show)

--- a/src/GraphQL/TypeApi.hs
+++ b/src/GraphQL/TypeApi.hs
@@ -230,7 +230,14 @@ instance forall f fs m.
         -- NB "alias" is encoded in-band. It cannot be set to empty in
         -- a query so the empty value means "no alias" and we use the
         -- name instead.
-        let name' = GValue.Name $ if alias == "" then name else alias
+
+        -- TODO: We need to use 'unsafeMakeName' here (which might panic)
+        -- because our API is currently written in terms of the Data.GraphQL
+        -- parser, which provides no type-level guarantees of name safety. We
+        -- should instead have our APIs in terms of 'Canonicalquery' (and the
+        -- rest of 'Data.GraphQL.Input', not yet written), and have that be
+        -- responsible for rejecting queries with invalid names.
+        let name' = GValue.unsafeMakeName $ if alias == "" then name else alias
         pure (GValue.ObjectField name' value)
 
   runFields _ f = queryError ("Unexpected Selection value. Is the query normalized?: " <> show f)

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -14,11 +14,12 @@ module GraphQL.Value
   , Object
   , ObjectField(ObjectField)
     -- ** Constructing
-  , objectFields
   , makeObject
   , objectFromList
     -- ** Combining
   , unionObjects
+    -- ** Querying
+  , objectFields
   ) where
 
 import Protolude
@@ -36,7 +37,8 @@ newtype Name = Name { getName :: Text } deriving (Eq, Ord, Show, IsString)
 instance ToJSON Name where
   toJSON = toJSON . getName
 
--- TODO: Add a smart constructor for Name.
+-- TODO: Add a smart constructor for Name, and have a custom instance of
+-- IsString that panics if it's invalid.
 
 -- | Concrete GraphQL value. Essentially Data.GraphQL.AST.Value, but without
 -- the "variable" field.

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -36,7 +36,7 @@ import qualified Data.GraphQL.Parser as Parser
 -- | A name in GraphQL.
 --
 -- https://facebook.github.io/graphql/#sec-Names
-newtype Name = Name { getName :: Text } deriving (Eq, Ord, Show, IsString)
+newtype Name = Name { getName :: Text } deriving (Eq, Ord, Show)
 
 instance ToJSON Name where
   toJSON = toJSON . getName

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -57,10 +57,8 @@ makeName = map Name . hush . parseOnly Parser.name
 --
 -- Prefer 'makeName' to this in all cases.
 --
--- >>> makeName "foo"
--- Just (Name {getName = "foo"})
--- >>> makeName "9-bar"
--- Nothing
+-- >>> unsafeMakeName "foo"
+-- Name {getName = "foo"}
 unsafeMakeName :: Text -> Name
 unsafeMakeName name = fromMaybe (panic $ "Not a valid GraphQL name: " <> show name) (makeName name)
 

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -35,10 +35,10 @@ import GraphQL.Schema
   , Type(..)
   , TypeDefinition(..)
   , NonNullType(..)
-  , Name(..)
   , Builtin(..)
   , InputType(..)
   )
+import GraphQL.Value (unsafeMakeName)
 
 -- Examples taken from the spec
 
@@ -95,33 +95,33 @@ tests :: IO TestTree
 tests = testSpec "Type" $ do
   describe "Field" $
     it "encodes correctly" $ do
-    getFieldDefinition @(Field "hello" Int) `shouldBe` FieldDefinition (Name "hello") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GInt)))
+    getFieldDefinition @(Field "hello" Int) `shouldBe` FieldDefinition (unsafeMakeName "hello") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GInt)))
   describe "Interface" $
     it "encodes correctly" $ do
     getInterfaceDefinition @Sentient `shouldBe`
       InterfaceTypeDefinition
-        (Name "Sentient")
-        (NonEmptyList [FieldDefinition (Name "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
+        (unsafeMakeName "Sentient")
+        (NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
   describe "full example" $
     it "encodes correctly" $ do
     getDefinition @Human `shouldBe`
-      ObjectTypeDefinition (Name "Human")
-        [ InterfaceTypeDefinition (Name "Sentient") (
-            NonEmptyList [FieldDefinition (Name "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
+      ObjectTypeDefinition (unsafeMakeName "Human")
+        [ InterfaceTypeDefinition (unsafeMakeName "Sentient") (
+            NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
         ]
-        (NonEmptyList [FieldDefinition (Name "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
+        (NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
   describe "output Enum" $
     it "encodes correctly" $ do
     getAnnotatedType @DogCommand `shouldBe`
-       TypeNonNull (NonNullTypeNamed (DefinedType (TypeDefinitionEnum (EnumTypeDefinition (Name "DogCommand")
-         [ EnumValueDefinition (Name "SIT")
-         , EnumValueDefinition (Name "DOWN")
-         , EnumValueDefinition (Name "HEEL")
+       TypeNonNull (NonNullTypeNamed (DefinedType (TypeDefinitionEnum (EnumTypeDefinition (unsafeMakeName "DogCommand")
+         [ EnumValueDefinition (unsafeMakeName "SIT")
+         , EnumValueDefinition (unsafeMakeName "DOWN")
+         , EnumValueDefinition (unsafeMakeName "HEEL")
          ]))))
   describe "Union type" $
     it "encodes correctly" $ do
     getAnnotatedType @CatOrDog `shouldBe`
-      TypeNamed (DefinedType (TypeDefinitionUnion (UnionTypeDefinition (Name "CatOrDog")
+      TypeNamed (DefinedType (TypeDefinitionUnion (UnionTypeDefinition (unsafeMakeName "CatOrDog")
         (NonEmptyList [ getDefinition @Cat
                       , getDefinition @Dog
                       ]

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -45,7 +45,7 @@ import GraphQL.Value (unsafeMakeName)
 data DogCommandEnum = Sit | Down | Heel
 
 instance GraphQLEnum DogCommandEnum where
-  enumValues = ["SIT", "DOWN", "HEEL"]
+  enumValues = map unsafeMakeName ["SIT", "DOWN", "HEEL"]
   enumToValue _ = undefined
   enumFromValue _ = undefined
 
@@ -71,7 +71,7 @@ type Human = Object "Human" '[Sentient] '[Field "name" Text]
 
 data CatCommandEnum = Jump
 instance GraphQLEnum CatCommandEnum where
-  enumValues = ["JUMP"]
+  enumValues = [unsafeMakeName "JUMP"]
   enumToValue = undefined
   enumFromValue = undefined
 

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -9,6 +9,7 @@ import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
 import GraphQL.Value
   ( Object(..)
   , ObjectField(..)
+  , unsafeMakeName
   , unionObjects
   , objectFromList
   , toValue
@@ -20,16 +21,19 @@ tests = testSpec "Value" $ do
     it "returns empty on empty list" $ do
       unionObjects [] `shouldBe` objectFromList []
     it "merges objects" $ do
-      let (Just foo) = objectFromList [("foo", toValue @Int32 1),("bar",toValue @Int32 2)]
-      let (Just bar) = objectFromList [("bar", toValue @Text "cow"),("baz",toValue @Int32 3)]
+      let (Just foo) = objectFromList [ (unsafeMakeName "foo", toValue @Int32 1)
+                                      , (unsafeMakeName "bar",toValue @Int32 2)]
+      let (Just bar) = objectFromList [ (unsafeMakeName "bar", toValue @Text "cow")
+                                      , (unsafeMakeName "baz",toValue @Int32 3)]
       let observed = unionObjects [foo, bar]
       observed `shouldBe` Nothing
     it "merges objects with unique keys" $ do
-      let (Just foo) = objectFromList [("foo", toValue @Int32 1)]
-      let (Just bar) = objectFromList [("bar", toValue @Text "cow"),("baz",toValue @Int32 3)]
-      let (Just expected) = objectFromList [ ("foo", toValue @Int32 1)
-                                           , ("bar", toValue @Text "cow")
-                                           , ("baz", toValue @Int32 3)
+      let (Just foo) = objectFromList [(unsafeMakeName "foo", toValue @Int32 1)]
+      let (Just bar) = objectFromList [ (unsafeMakeName "bar", toValue @Text "cow")
+                                      , (unsafeMakeName "baz",toValue @Int32 3)]
+      let (Just expected) = objectFromList [ (unsafeMakeName "foo", toValue @Int32 1)
+                                           , (unsafeMakeName "bar", toValue @Text "cow")
+                                           , (unsafeMakeName "baz", toValue @Int32 3)
                                            ]
       let (Just observed) = unionObjects [foo, bar]
       observed `shouldBe` expected


### PR DESCRIPTION
The quest to remove TODOs never ends. Although this removes one, it makes another.

Builds on https://github.com/jml/graphql-api/pull/24, so review & merge that before reviewing this (or just review https://github.com/jml/graphql-api/pull/26/commits/ddbd8afbb4723f15236a039618a09a925cec0946).

Was going to do QuickCheck instances in this as per #23 but this turned out to be more complicated than expected and also now I really have to go.

## Smart constructor for Name

Name is restricted in value, so when we have something that accepts a `Name` as a parameter, it should be able to trust that it's valid.

Stopped exporting `Name` constructor and now export two constructors:

 1. `makeName`
 2. `unsafeMakeName`

They do what they say on the tin.

There are three use-cases for `unsafeMakeName`:

 1. In tests, where we are passing a literal.
 2. In `Definitions`, because we cannot get GHC to enforce a restricted set of values for a `Symbol`.
 3. In `TypeApi`, because we're operating on Data.GraphQL.AST directly when we should be operating on a pre-restricted type. Noted as a TODO comment.

I tried adding a `HasName` type class to `Definitions`, but couldn't figure it out in the ten minutes I gave myself.

## Misc cleanups

* Dropped superfluous parens
