### PR TITLE
QuickCheck for Values

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -33,6 +33,7 @@ library
     , aeson
     , containers
     , graphql
+    , QuickCheck
     , text
   exposed-modules:
       GraphQL.Definitions
@@ -84,6 +85,7 @@ test-suite graphql-api-tests
     , containers
     , graphql
     , graphql-api
+    , hspec
     , tasty
     , tasty-hspec
   other-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,7 @@ library:
     - aeson
     - containers
     - graphql
+    - QuickCheck
     - text
 
 tests:
@@ -38,6 +39,7 @@ tests:
       - containers
       - graphql
       - graphql-api
+      - hspec
       - tasty
       - tasty-hspec
 

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -5,6 +5,7 @@ import Protolude
 
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec.QuickCheck (prop)
 
 import GraphQL.Value
   ( Object(..)
@@ -38,6 +39,9 @@ tests = testSpec "Value" $ do
       let (Just observed) = unionObjects [foo, bar]
       observed `shouldBe` expected
       expected `shouldSatisfy` prop_fieldsUnique
+  describe "Objects" $ do
+    prop "have unique fields" $ do
+      prop_fieldsUnique
 
 
 -- | All of the fields in an object should have unique names.


### PR DESCRIPTION
Pretty boring (at last). Depends on #26.

Fixes #23.

Note that `List` is too generously typed. I can't think of a good way of encoding homogeneous lists without adding a type parameter. I think we'll have to suck that one up.