### PR TITLE
Make TypeApplications a default language extension

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.14.1.
+-- This file has been generated from package.yaml by hpack version 0.15.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -22,7 +22,7 @@ source-repository head
 library
   hs-source-dirs:
       src
-  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards
+  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
       base >= 4.9 && < 5
@@ -50,7 +50,7 @@ test-suite graphql-api-doctests
   main-is: Doctests.hs
   hs-source-dirs:
       tests
-  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards
+  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints -threaded
   build-depends:
       base >= 4.9 && < 5
@@ -73,7 +73,7 @@ test-suite graphql-api-tests
   main-is: Spec.hs
   hs-source-dirs:
       tests
-  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards
+  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
       base >= 4.9 && < 5

--- a/package.yaml
+++ b/package.yaml
@@ -13,6 +13,7 @@ default-extensions:
   - NoImplicitPrelude
   - OverloadedStrings
   - RecordWildCards
+  - TypeApplications
 
 dependencies:
   - base >= 4.9 && < 5

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeFamilies, ScopedTypeVariables, TypeFamilyDependencies #-}
 {-# LANGUAGE GADTs, AllowAmbiguousTypes, UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses, RankNTypes #-}
-{-# LANGUAGE FlexibleInstances, TypeOperators, TypeApplications, TypeInType #-}
+{-# LANGUAGE FlexibleInstances, TypeOperators, TypeInType #-}
 {-# LANGUAGE OverloadedLabels, MagicHash #-}
 
 -- | Type-level definitions for a GraphQL schema.

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -1,13 +1,12 @@
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-} -- for TypeError
 
 module GraphQL.Server

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Literal GraphQL values.
 module GraphQL.Value

--- a/tests/Doctests.hs
+++ b/tests/Doctests.hs
@@ -12,6 +12,7 @@ main = doctest $ ["-isrc"] <> options <> files
     extensions = [ "NoImplicitPrelude"
                  , "OverloadedStrings"
                  , "RecordWildCards"
+                 , "TypeApplications"
                  ]
     -- All of our source files.
     files = [ "src/" ]

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE DataKinds #-}
 module Examples.UnionExample  where
 

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeApplications, DataKinds, TypeOperators, ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds, TypeOperators, ScopedTypeVariables #-}
 module TypeApiTests (tests) where
 
 import Protolude hiding (Enum)

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeApplications, DataKinds, TypeOperators #-}
+{-# LANGUAGE DataKinds, TypeOperators #-}
 module TypeTests (tests) where
 
 import Protolude hiding (Enum)

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TypeApplications #-}
 module ValueTests (tests) where
 
 import Protolude


### PR DESCRIPTION
I figure we're using it so much that it basically counts as a style thing that should be consistently available across the code base.