### PR TITLE
Roundtrip strings

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+hlint -XTypeApplications src/ tests/

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -174,8 +174,8 @@ data InterfaceTypeDefinition = InterfaceTypeDefinition Name [FieldDefinition]
 data UnionTypeDefinition = UnionTypeDefinition Name [NamedType]
                            deriving (Eq,Show)
 
-data ScalarTypeDefinition = ScalarTypeDefinition Name
-                            deriving (Eq,Show)
+newtype ScalarTypeDefinition = ScalarTypeDefinition Name
+                             deriving (Eq,Show)
 
 data EnumTypeDefinition = EnumTypeDefinition Name [EnumValueDefinition]
                           deriving (Eq,Show)

--- a/src/GraphQL/Internal/Encoder.hs
+++ b/src/GraphQL/Internal/Encoder.hs
@@ -5,6 +5,7 @@ module GraphQL.Internal.Encoder
 
 import Protolude hiding (Type, intercalate)
 
+import qualified Data.Aeson as Aeson
 import Data.Text (Text, cons, intercalate, pack, snoc)
 
 import qualified GraphQL.Internal.AST as AST
@@ -104,7 +105,7 @@ booleanValue False = "false"
 
 -- TODO: Escape characters
 stringValue :: AST.StringValue -> Text
-stringValue (AST.StringValue v) = quotes v
+stringValue (AST.StringValue v) = toS $ Aeson.encode v
 
 listValue :: AST.ListValue -> Text
 listValue (AST.ListValue vs) = bracketsCommas value vs
@@ -223,9 +224,6 @@ brackets = between '[' ']'
 
 braces :: Text -> Text
 braces = between '{' '}'
-
-quotes :: Text -> Text
-quotes = between '"' '"'
 
 spaces :: (a -> Text) -> [a] -> Text
 spaces f = intercalate "\SP" . fmap f

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -162,7 +162,7 @@ value = AST.ValueVariable <$> variable
   where
     number =  do
       (numText, num) <- match (tok scientific)
-      case ((Data.Text.find (== '.') numText), floatingOrInteger num) of
+      case (Data.Text.find (== '.') numText, floatingOrInteger num) of
         (Just _, Left r) -> pure (AST.ValueFloat r)
         (Just _, Right i) -> pure (AST.ValueFloat (fromIntegral i))
         -- TODO: Handle maxBound, Int32 in spec.

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 module GraphQL.Internal.Parser
   ( document
   , name
@@ -7,16 +8,18 @@ module GraphQL.Internal.Parser
 import Protolude hiding (Type, takeWhile)
 
 import Control.Applicative ((<|>), empty, many, optional)
-import Control.Monad (when)
+import Control.Monad (fail, when)
+import Data.Aeson.Parser (jstring)
 import Data.Char (isDigit, isSpace)
 import Data.Foldable (traverse_)
 import Data.Scientific (floatingOrInteger)
-
 import Data.Text (Text, append, find)
+import qualified Data.Attoparsec.ByteString as A
 import Data.Attoparsec.Text
   ( Parser
   , (<?>)
   , anyChar
+  , char
   , endOfLine
   , inClass
   , match
@@ -24,6 +27,7 @@ import Data.Attoparsec.Text
   , manyTill
   , option
   , peekChar
+  , scan
   , scientific
   , sepBy1
   , takeWhile
@@ -39,7 +43,7 @@ name = tok $ append <$> takeWhile1 isA_z
                     <*> takeWhile ((||) <$> isDigit <*> isA_z)
   where
     -- `isAlpha` handles many more Unicode Chars
-    isA_z =  inClass $ '_' : ['A'..'Z'] ++ ['a'..'z']
+    isA_z =  inClass $ '_' : ['A'..'Z'] <> ['a'..'z']
 
 -- * Document
 
@@ -173,9 +177,31 @@ booleanValue :: Parser Bool
 booleanValue = True  <$ tok "true"
    <|> False <$ tok "false"
 
--- TODO: Escape characters. Look at `jsstring_` in aeson package.
 stringValue :: Parser AST.StringValue
-stringValue = AST.StringValue <$> quotes (takeWhile (/= '"'))
+stringValue = do
+  parsed <- char '"' *> jstring_
+  case unescapeText parsed of
+    Left err -> fail err
+    Right escaped -> pure (AST.StringValue escaped)
+  where
+    -- | Parse a string without a leading quote, ignoring any escaped characters.
+    jstring_ :: Parser Text
+    jstring_ = scan startState go <* anyChar
+
+    startState = False
+    go a c
+      | a = Just False
+      | c == '"' = Nothing
+      | otherwise = let a' = c == backslash
+                    in Just a'
+      where backslash = '\\'
+
+    -- | Unescape a string.
+    --
+    -- Turns out this is really tricky, so we're going to cheat by
+    -- reconstructing a literal string (by putting quotes around it) and
+    -- delegating all the hard work to Aeson.
+    unescapeText str = A.parseOnly jstring ("\"" <> toS str <> "\"")
 
 -- Notice it can be empty
 listValue :: Parser AST.ListValue
@@ -318,9 +344,6 @@ parens = between "(" ")"
 
 braces :: Parser a -> Parser a
 braces = between "{" "}"
-
-quotes :: Parser a -> Parser a
-quotes = between "\"" "\""
 
 brackets :: Parser a -> Parser a
 brackets = between "[" "]"

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -11,7 +11,7 @@ module GraphQL.Value
   , makeName
   , unsafeMakeName
   , List
-  , String
+  , String(..)
     -- * Objects
   , Object
   , ObjectField(ObjectField)

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -35,8 +35,8 @@ tests = testSpec "AST" $ do
       it "parses lists of floats" $ do
         let input = AST.ValueList
                       (AST.ListValue
-                       [ (AST.ValueFloat 1.5)
-                       , (AST.ValueFloat 1.5)
+                       [ AST.ValueFloat 1.5
+                       , AST.ValueFloat 1.5
                        ])
         let output = Encoder.value input
         output `shouldBe` "[1.5,1.5]"

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -7,6 +7,7 @@ import Test.Hspec.QuickCheck (prop)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
+import GraphQL.Value (String(..))
 import qualified GraphQL.Internal.AST as AST
 import qualified GraphQL.Internal.Parser as Parser
 import qualified GraphQL.Internal.Encoder as Encoder
@@ -31,6 +32,18 @@ tests = testSpec "AST" $ do
         parseOnly Parser.value "0.0" `shouldBe` Right (AST.ValueFloat 0.0)
       prop "works for floats" $ do
         \x -> parseOnly Parser.value (show x) == Right (AST.ValueFloat x)
+    describe "strings" $ do
+      prop "works for all strings" $ do
+        \(String x) ->
+          let input = AST.ValueString (AST.StringValue x)
+              output = Encoder.value input in
+          parseOnly Parser.value output == Right input
+      it "handles unusual strings" $ do
+        let input = AST.ValueString (AST.StringValue "\fh\244")
+        let output = Encoder.value input
+        -- \f is \u000c
+        output `shouldBe` "\"\\u000ch\244\""
+        parseOnly Parser.value output `shouldBe` Right input
     describe "parsing values" $ do
       it "parses lists of floats" $ do
         let input = AST.ValueList
@@ -41,3 +54,4 @@ tests = testSpec "AST" $ do
         let output = Encoder.value input
         output `shouldBe` "[1.5,1.5]"
         parseOnly Parser.value output `shouldBe` Right input
+


### PR DESCRIPTION
Turns out graphql doesn't support escaped strings. This makes it do so by re-using Aeson's code, on the assumption that GraphQL strings are identical to JSON strings.