### PR TITLE
WIP: Full value roundtrip

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -89,6 +89,7 @@ test-suite graphql-api-tests
     , containers
     , graphql-api
     , hspec
+    , QuickCheck
     , tasty
     , tasty-hspec
   other-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ tests:
       - containers
       - graphql-api
       - hspec
+      - QuickCheck
       - tasty
       - tasty-hspec
 

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -154,14 +154,14 @@ typeCondition = namedType
 -- This will try to pick the first type it can parse. If you are working with
 -- explicit types use the `typedValue` parser.
 value :: Parser AST.Value
-value = AST.ValueVariable <$> variable
-  <|> number
-  <|> AST.ValueBoolean  <$> booleanValue
-  <|> AST.ValueString   <$> stringValue
+value = AST.ValueVariable <$> (variable <?> "variable")
+  <|> (number <?> "number")
+  <|> AST.ValueBoolean  <$> (booleanValue <?> "booleanValue")
+  <|> AST.ValueString   <$> (stringValue <?> "stringValue")
   -- `true` and `false` have been tried before
-  <|> AST.ValueEnum     <$> name
-  <|> AST.ValueList     <$> listValue
-  <|> AST.ValueObject   <$> objectValue
+  <|> AST.ValueEnum     <$> (name <?> "name")
+  <|> AST.ValueList     <$> (listValue <?> "listValue")
+  <|> AST.ValueObject   <$> (objectValue <?> "objectValue")
   <?> "value error!"
   where
     number =  do
@@ -209,10 +209,10 @@ listValue = AST.ListValue <$> brackets (many value)
 
 -- Notice it can be empty
 objectValue :: Parser AST.ObjectValue
-objectValue = AST.ObjectValue <$> braces (many objectField)
+objectValue = AST.ObjectValue <$> braces (many (objectField <?> "objectField"))
 
 objectField :: Parser AST.ObjectField
-objectField = AST.ObjectField <$> name <* tok ":" <*> value
+objectField = AST.ObjectField <$> name <* tok ":" <*> tok value
 
 -- * Directives
 

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -154,7 +154,7 @@ typeCondition = namedType
 -- This will try to pick the first type it can parse. If you are working with
 -- explicit types use the `typedValue` parser.
 value :: Parser AST.Value
-value = AST.ValueVariable <$> (variable <?> "variable")
+value = tok (AST.ValueVariable <$> (variable <?> "variable")
   <|> (number <?> "number")
   <|> AST.ValueBoolean  <$> (booleanValue <?> "booleanValue")
   <|> AST.ValueString   <$> (stringValue <?> "stringValue")
@@ -162,7 +162,7 @@ value = AST.ValueVariable <$> (variable <?> "variable")
   <|> AST.ValueEnum     <$> (name <?> "name")
   <|> AST.ValueList     <$> (listValue <?> "listValue")
   <|> AST.ValueObject   <$> (objectValue <?> "objectValue")
-  <?> "value error!"
+  <?> "value error!")
   where
     number =  do
       (numText, num) <- match (tok scientific)
@@ -212,7 +212,7 @@ objectValue :: Parser AST.ObjectValue
 objectValue = AST.ObjectValue <$> braces (many (objectField <?> "objectField"))
 
 objectField :: Parser AST.ObjectField
-objectField = AST.ObjectField <$> name <* tok ":" <*> tok value
+objectField = AST.ObjectField <$> name <* tok ":" <*> value
 
 -- * Directives
 

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -4,7 +4,7 @@ import Protolude
 
 import Data.Attoparsec.Text (parseOnly)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Gen, arbitrary, discard, forAll)
+import Test.QuickCheck (Gen, arbitrary, discard, forAll, verbose)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
@@ -52,7 +52,7 @@ tests = testSpec "AST" $ do
         parseOnly Parser.value output `shouldBe` Right input
     describe "parsing values" $ do
       prop "works for all literal values" $ do
-        forAll genASTValue $ \x -> (parseOnly Parser.value . Encoder.value) x `shouldBe` Right x
+        forAll genASTValue $ \x -> verbose $ (parseOnly Parser.value) (Encoder.value x) `shouldBe` Right x
       it "parses ununusual objects" $ do
         let input = AST.ValueObject
                     (AST.ObjectValue
@@ -60,7 +60,7 @@ tests = testSpec "AST" $ do
                        (AST.ValueString (AST.StringValue "\224\225v^6{FPDk\DC3\a")),
                        AST.ObjectField "Hsr" (AST.ValueInt 0)
                      ])
-        let output = Encoder.value input
+        let output = traceShowId $ Encoder.value input
         parseOnly Parser.value output `shouldBe` Right input
       it "parses lists of floats" $ do
         let input = AST.ValueList
@@ -71,4 +71,3 @@ tests = testSpec "AST" $ do
         let output = Encoder.value input
         output `shouldBe` "[1.5,1.5]"
         parseOnly Parser.value output `shouldBe` Right input
-

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -4,16 +4,22 @@ import Protolude
 
 import Data.Attoparsec.Text (parseOnly)
 import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (Gen, arbitrary, discard, forAll)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
-import GraphQL.Value (String(..))
+import GraphQL.Value (String(..), valueToAST)
 import qualified GraphQL.Internal.AST as AST
 import qualified GraphQL.Internal.Parser as Parser
 import qualified GraphQL.Internal.Encoder as Encoder
 
 kitchenSink :: Text
 kitchenSink = "query queryName($foo:ComplexType,$site:Site=MOBILE){whoever123is:node(id:[123,456]){id,... on User@defer{field2{id,alias:field1(first:10,after:$foo)@include(if:$foo){id,...frag}}}}}mutation likeStory{like(story:123)@defer{story{id}}}fragment frag on Friend{foo(size:$size,bar:$b,obj:{key:\"value\"})}\n"
+
+genASTValue :: Gen AST.Value
+genASTValue = do
+  v <- valueToAST <$> arbitrary
+  maybe discard pure v
 
 tests :: IO TestTree
 tests = testSpec "AST" $ do
@@ -45,6 +51,17 @@ tests = testSpec "AST" $ do
         output `shouldBe` "\"\\u000ch\244\""
         parseOnly Parser.value output `shouldBe` Right input
     describe "parsing values" $ do
+      prop "works for all literal values" $ do
+        forAll genASTValue $ \x -> (parseOnly Parser.value . Encoder.value) x `shouldBe` Right x
+      it "parses ununusual objects" $ do
+        let input = AST.ValueObject
+                    (AST.ObjectValue
+                     [ AST.ObjectField "s"
+                       (AST.ValueString (AST.StringValue "\224\225v^6{FPDk\DC3\a")),
+                       AST.ObjectField "Hsr" (AST.ValueInt 0)
+                     ])
+        let output = Encoder.value input
+        parseOnly Parser.value output `shouldBe` Right input
       it "parses lists of floats" $ do
         let input = AST.ValueList
                       (AST.ListValue

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -4,7 +4,7 @@ import Protolude
 
 import Data.Attoparsec.Text (parseOnly)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Gen, arbitrary, discard, forAll, verbose)
+import Test.QuickCheck (Gen, arbitrary, discard, forAll)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
@@ -52,7 +52,7 @@ tests = testSpec "AST" $ do
         parseOnly Parser.value output `shouldBe` Right input
     describe "parsing values" $ do
       prop "works for all literal values" $ do
-        forAll genASTValue $ \x -> verbose $ (parseOnly Parser.value) (Encoder.value x) `shouldBe` Right x
+        forAll genASTValue $ \x -> (parseOnly Parser.value) (Encoder.value x) `shouldBe` Right x
       it "parses ununusual objects" $ do
         let input = AST.ValueObject
                     (AST.ObjectValue
@@ -60,7 +60,7 @@ tests = testSpec "AST" $ do
                        (AST.ValueString (AST.StringValue "\224\225v^6{FPDk\DC3\a")),
                        AST.ObjectField "Hsr" (AST.ValueInt 0)
                      ])
-        let output = traceShowId $ Encoder.value input
+        let output = Encoder.value input
         parseOnly Parser.value output `shouldBe` Right input
       it "parses lists of floats" $ do
         let input = AST.ValueList


### PR DESCRIPTION
#37 does this for strings, this does it for all values. Review & merge #37 first to see a good diff for this.

Adds quickcheck tests for roundtripping values. They currently fail, but not on every run. I've added a test that exercises the broken path, but I haven't had time to minimize.

It might be useful to begin by adding better shrinking support to the `Arbitrary` instances we already have. That's what I'm going to do next time I face quickcheck failures.

