### PR TITLE
Mixed bag

### DIFF
--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -1,0 +1,12 @@
+module Main (main) where
+
+import Protolude
+
+import Criterion.Main (bgroup, defaultMain)
+import qualified Validation
+
+
+main :: IO ()
+main = do
+  defaultMain [ bgroup "GraphQL API" Validation.benchmarks
+              ]

--- a/benchmarks/Validation.hs
+++ b/benchmarks/Validation.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE TypeApplications #-}
+module Validation (benchmarks) where
+
+import Protolude
+
+import Criterion (Benchmark, bench, nf)
+import GraphQL.Internal.Validation (findDuplicates)
+
+
+benchmarks :: [Benchmark]
+benchmarks =
+  [ bench "findDuplicates" (nf findDuplicates exampleData)
+  ]
+  where
+    exampleData :: [Int]
+    exampleData = [2, 8, 9, 8, 1, 7, 5, 0, 1, 3, 5, 4]

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -90,6 +90,7 @@ test-suite graphql-api-tests
     , graphql-api
     , hspec
     , QuickCheck
+    , raw-strings-qq
     , tasty
     , tasty-hspec
   other-modules:

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -101,3 +101,22 @@ test-suite graphql-api-tests
       ValidationTests
       ValueTests
   default-language: Haskell2010
+
+benchmark criterion
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs:
+      benchmarks
+  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards
+  ghc-options: -Wall -fno-warn-redundant-constraints
+  build-depends:
+      base >= 4.9 && < 5
+    , protolude
+    , exceptions
+    , transformers
+    , attoparsec
+    , criterion
+    , graphql-api
+  other-modules:
+      Validation
+  default-language: Haskell2010

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -107,7 +107,7 @@ benchmark criterion
   main-is: Main.hs
   hs-source-dirs:
       benchmarks
-  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards
+  default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
       base >= 4.9 && < 5

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -43,6 +43,7 @@ library
       GraphQL.Internal.Output
       GraphQL.Internal.Parser
       GraphQL.Internal.Schema
+      GraphQL.Internal.Tokens
       GraphQL.Internal.Validation
       GraphQL.Server
       GraphQL.Value

--- a/package.yaml
+++ b/package.yaml
@@ -51,3 +51,11 @@ tests:
     source-dirs: tests
     dependencies:
       - doctest
+
+benchmarks:
+  criterion:
+    main: Main.hs
+    source-dirs: benchmarks
+    dependencies:
+      - criterion
+      - graphql-api

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ tests:
       - graphql-api
       - hspec
       - QuickCheck
+      - raw-strings-qq
       - tasty
       - tasty-hspec
 

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -1,5 +1,6 @@
 module GraphQL.Internal.AST
   ( Name
+  , pName
   , Document(..)
   , Definition(..)
   , OperationDefinition(..)
@@ -44,12 +45,23 @@ module GraphQL.Internal.AST
 
 import Protolude hiding (Type)
 
+import Data.Char (isDigit)
+import qualified Data.Attoparsec.Text as A
+import GraphQL.Internal.Tokens (tok)
+
 -- TODO: Our GraphQL.Value.Name has more guarantees than AST.Name (which is
 -- just a Text alias). We should change that so AST.Name is guaranteed valid.
 
 -- * Name
 
 type Name = Text
+
+pName :: A.Parser Name
+pName = tok $ (<>) <$> A.takeWhile1 isA_z
+                   <*> A.takeWhile ((||) <$> isDigit <*> isA_z)
+  where
+    -- `isAlpha` handles many more Unicode Chars
+    isA_z = A.inClass $ '_' : ['A'..'Z'] <> ['a'..'z']
 
 -- * Document
 

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -1,6 +1,6 @@
 module GraphQL.Internal.AST
   ( Name
-  , pName
+  , nameParser
   , Document(..)
   , Definition(..)
   , OperationDefinition(..)
@@ -56,8 +56,8 @@ import GraphQL.Internal.Tokens (tok)
 
 type Name = Text
 
-pName :: A.Parser Name
-pName = tok $ (<>) <$> A.takeWhile1 isA_z
+nameParser :: A.Parser Name
+nameParser = tok $ (<>) <$> A.takeWhile1 isA_z
                    <*> A.takeWhile ((||) <$> isDigit <*> isA_z)
   where
     -- `isAlpha` handles many more Unicode Chars

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -4,6 +4,7 @@ module GraphQL.Internal.AST
   , Definition(..)
   , OperationDefinition(..)
   , Node(..)
+  , getNodeName
   , VariableDefinition(..)
   , Variable(..)
   , SelectionSet
@@ -52,19 +53,24 @@ type Name = Text
 
 -- * Document
 
-newtype Document = Document [Definition] deriving (Eq,Show)
+newtype Document = Document { getDefinitions :: [Definition] } deriving (Eq,Show)
 
 data Definition = DefinitionOperation OperationDefinition
                 | DefinitionFragment  FragmentDefinition
                 | DefinitionType      TypeDefinition
                   deriving (Eq,Show)
 
-data OperationDefinition = Query    Node
-                         | Mutation Node
+data OperationDefinition = Query    { getNode :: Node }
+                         | Mutation { getNode :: Node }
                            deriving (Eq,Show)
 
 data Node = Node Name [VariableDefinition] [Directive] SelectionSet
             deriving (Eq,Show)
+
+-- XXX: Lots of things have names. Maybe we should define a typeclass for
+-- getting the name?
+getNodeName :: Node -> Name
+getNodeName (Node name _ _ _) = name
 
 data VariableDefinition = VariableDefinition Variable Type (Maybe DefaultValue)
                           deriving (Eq,Show)

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -44,8 +44,8 @@ module GraphQL.Internal.AST
 
 import Protolude hiding (Type)
 
-import Data.Int (Int32)
-import Data.Text (Text)
+-- TODO: Our GraphQL.Value.Name has more guarantees than AST.Name (which is
+-- just a Text alias). We should change that so AST.Name is guaranteed valid.
 
 -- * Name
 

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -54,7 +54,7 @@ operationDefinition =
   <?> "operationDefinition error!"
 
 node :: Parser AST.Node
-node = AST.Node <$> AST.pName
+node = AST.Node <$> AST.nameParser
                 <*> optempty variableDefinitions
                 <*> optempty directives
                 <*> selectionSet
@@ -73,7 +73,7 @@ defaultValue :: Parser AST.DefaultValue
 defaultValue = tok "=" *> value
 
 variable :: Parser AST.Variable
-variable = AST.Variable <$ tok "$" <*> AST.pName
+variable = AST.Variable <$ tok "$" <*> AST.nameParser
 
 selectionSet :: Parser AST.SelectionSet
 selectionSet = braces $ many1 selection
@@ -87,19 +87,19 @@ selection = AST.SelectionField <$> field
 
 field :: Parser AST.Field
 field = AST.Field <$> optempty alias
-                  <*> AST.pName
+                  <*> AST.nameParser
                   <*> optempty arguments
                   <*> optempty directives
                   <*> optempty selectionSet
 
 alias :: Parser AST.Alias
-alias = AST.pName <* tok ":"
+alias = AST.nameParser <* tok ":"
 
 arguments :: Parser [AST.Argument]
 arguments = parens $ many1 argument
 
 argument :: Parser AST.Argument
-argument = AST.Argument <$> AST.pName <* tok ":" <*> value
+argument = AST.Argument <$> AST.nameParser <* tok ":" <*> value
 
 -- * Fragments
 
@@ -108,7 +108,7 @@ fragmentSpread :: Parser AST.FragmentSpread
 -- See https://facebook.github.io/graphql/#FragmentSpread
 fragmentSpread = AST.FragmentSpread
   <$  tok "..."
-  <*> AST.pName
+  <*> AST.nameParser
   <*> optempty directives
 
 -- InlineFragment tried first in order to guard against 'on' keyword
@@ -123,7 +123,7 @@ inlineFragment = AST.InlineFragment
 fragmentDefinition :: Parser AST.FragmentDefinition
 fragmentDefinition = AST.FragmentDefinition
   <$  tok "fragment"
-  <*> AST.pName
+  <*> AST.nameParser
   <*  tok "on"
   <*> typeCondition
   <*> optempty directives
@@ -142,7 +142,7 @@ value = tok (AST.ValueVariable <$> (variable <?> "variable")
   <|> AST.ValueBoolean  <$> (booleanValue <?> "booleanValue")
   <|> AST.ValueString   <$> (stringValue <?> "stringValue")
   -- `true` and `false` have been tried before
-  <|> AST.ValueEnum     <$> (AST.pName <?> "name")
+  <|> AST.ValueEnum     <$> (AST.nameParser <?> "name")
   <|> AST.ValueList     <$> (listValue <?> "listValue")
   <|> AST.ValueObject   <$> (objectValue <?> "objectValue")
   <?> "value error!")
@@ -195,7 +195,7 @@ objectValue :: Parser AST.ObjectValue
 objectValue = AST.ObjectValue <$> braces (many (objectField <?> "objectField"))
 
 objectField :: Parser AST.ObjectField
-objectField = AST.ObjectField <$> AST.pName <* tok ":" <*> value
+objectField = AST.ObjectField <$> AST.nameParser <* tok ":" <*> value
 
 -- * Directives
 
@@ -205,7 +205,7 @@ directives = many1 directive
 directive :: Parser AST.Directive
 directive = AST.Directive
   <$  tok "@"
-  <*> AST.pName
+  <*> AST.nameParser
   <*> optempty arguments
 
 -- * Type Reference
@@ -217,7 +217,7 @@ type_ = AST.TypeList    <$> listType
     <?> "type_ error!"
 
 namedType :: Parser AST.NamedType
-namedType = AST.NamedType <$> AST.pName
+namedType = AST.NamedType <$> AST.nameParser
 
 listType :: Parser AST.ListType
 listType = AST.ListType <$> brackets type_
@@ -243,7 +243,7 @@ typeDefinition =
 objectTypeDefinition :: Parser AST.ObjectTypeDefinition
 objectTypeDefinition = AST.ObjectTypeDefinition
   <$  tok "type"
-  <*> AST.pName
+  <*> AST.nameParser
   <*> optempty interfaces
   <*> fieldDefinitions
 
@@ -255,7 +255,7 @@ fieldDefinitions = braces $ many1 fieldDefinition
 
 fieldDefinition :: Parser AST.FieldDefinition
 fieldDefinition = AST.FieldDefinition
-  <$> AST.pName
+  <$> AST.nameParser
   <*> optempty argumentsDefinition
   <*  tok ":"
   <*> type_
@@ -266,13 +266,13 @@ argumentsDefinition = parens $ many1 inputValueDefinition
 interfaceTypeDefinition :: Parser AST.InterfaceTypeDefinition
 interfaceTypeDefinition = AST.InterfaceTypeDefinition
   <$  tok "interface"
-  <*> AST.pName
+  <*> AST.nameParser
   <*> fieldDefinitions
 
 unionTypeDefinition :: Parser AST.UnionTypeDefinition
 unionTypeDefinition = AST.UnionTypeDefinition
   <$  tok "union"
-  <*> AST.pName
+  <*> AST.nameParser
   <*  tok "="
   <*> unionMembers
 
@@ -282,24 +282,24 @@ unionMembers = namedType `sepBy1` tok "|"
 scalarTypeDefinition :: Parser AST.ScalarTypeDefinition
 scalarTypeDefinition = AST.ScalarTypeDefinition
   <$  tok "scalar"
-  <*> AST.pName
+  <*> AST.nameParser
 
 enumTypeDefinition :: Parser AST.EnumTypeDefinition
 enumTypeDefinition = AST.EnumTypeDefinition
   <$  tok "enum"
-  <*> AST.pName
+  <*> AST.nameParser
   <*> enumValueDefinitions
 
 enumValueDefinitions :: Parser [AST.EnumValueDefinition]
 enumValueDefinitions = braces $ many1 enumValueDefinition
 
 enumValueDefinition :: Parser AST.EnumValueDefinition
-enumValueDefinition = AST.EnumValueDefinition <$> AST.pName
+enumValueDefinition = AST.EnumValueDefinition <$> AST.nameParser
 
 inputObjectTypeDefinition :: Parser AST.InputObjectTypeDefinition
 inputObjectTypeDefinition = AST.InputObjectTypeDefinition
   <$  tok "input"
-  <*> AST.pName
+  <*> AST.nameParser
   <*> inputValueDefinitions
 
 inputValueDefinitions :: Parser [AST.InputValueDefinition]
@@ -307,7 +307,7 @@ inputValueDefinitions = braces $ many1 inputValueDefinition
 
 inputValueDefinition :: Parser AST.InputValueDefinition
 inputValueDefinition = AST.InputValueDefinition
-  <$> AST.pName
+  <$> AST.nameParser
   <*  tok ":"
   <*> type_
   <*> optional defaultValue

--- a/src/GraphQL/Internal/Tokens.hs
+++ b/src/GraphQL/Internal/Tokens.hs
@@ -1,0 +1,24 @@
+-- | Basic tokenising used by parser.
+module GraphQL.Internal.Tokens
+  ( tok
+  , whiteSpace
+  ) where
+
+import Protolude
+import Data.Attoparsec.Text
+  ( Parser
+  , anyChar
+  , endOfLine
+  , peekChar
+  , manyTill
+  )
+import Data.Char (isSpace)
+
+tok :: Parser a -> Parser a
+tok p = p <* whiteSpace
+
+whiteSpace :: Parser ()
+whiteSpace = peekChar >>= traverse_ (\c ->
+  if isSpace c || c == ','
+    then anyChar *> whiteSpace
+    else when (c == '#') $ manyTill anyChar endOfLine *> whiteSpace)

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -3,6 +3,8 @@ module GraphQL.Internal.Validation
   , ValidDocument
   , validate
   , getErrors
+  -- * Exported for testing
+  , findDuplicates
   ) where
 
 import Protolude
@@ -67,8 +69,6 @@ data ValidationError
 
 -- XXX: Would Data.Validation make this better / simpler?
 
--- XXX: Lenses for the AST might be nice. If I knew lenses.
-
 -- XXX: Beginning to think that we might as well have Arbitrary instances for
 -- the AST and determine properties.
 
@@ -92,7 +92,10 @@ getNodeName :: AST.Node -> AST.Name
 getNodeName (AST.Node name _ _ _) = name
 
 
--- XXX: Untested, really should have tests.
+-- | Return a list of all the elements with duplicates. The list of duplicates
+-- itself will not contain duplicates.
+--
+-- prop> \xs -> findDuplicates @Int xs == ordNub (findDuplicates @Int xs)
 findDuplicates :: Ord a => [a] -> [a]
 findDuplicates xs = findDups (sort xs)
   where

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -67,29 +67,12 @@ data ValidationError
   = DuplicateOperation AST.Name
   deriving (Eq, Show)
 
--- XXX: Would Data.Validation make this better / simpler?
-
--- XXX: Beginning to think that we might as well have Arbitrary instances for
--- the AST and determine properties.
 
 getErrors :: AST.Document -> [ValidationError]
 getErrors doc = duplicateOperations
   where
     duplicateOperations = DuplicateOperation <$> findDuplicates nodeNames
-    nodeNames = [ getNodeName . getNode $ op | AST.DefinitionOperation op <- getDefinitions doc ]
-
-
-getDefinitions :: AST.Document -> [AST.Definition]
-getDefinitions (AST.Document defns) = defns
-
-getNode :: AST.OperationDefinition -> AST.Node
-getNode (AST.Query n) = n
-getNode (AST.Mutation n) = n
-
--- XXX: Lots of things have names. Maybe we should define a typeclass for
--- getting the name?
-getNodeName :: AST.Node -> AST.Name
-getNodeName (AST.Node name _ _ _) = name
+    nodeNames = [ AST.getNodeName . AST.getNode $ op | AST.DefinitionOperation op <- AST.getDefinitions doc ]
 
 
 -- | Return a list of all the elements with duplicates. The list of duplicates

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -191,7 +191,7 @@ executeNamedField (AST.Field alias name _ _ _) (NamedFieldExecutor k mValue)
 
 -- Deconstruct object type signature and handler value at the same
 -- time and run type-directed code for each field.
-resolveField :: forall a (m :: * -> *). BuildFieldResolver m a => m GValue.ObjectField -> FieldHandler m a -> AST.Selection -> m GValue.ObjectField
+resolveField :: forall a (m :: Type -> Type). BuildFieldResolver m a => m GValue.ObjectField -> FieldHandler m a -> AST.Selection -> m GValue.ObjectField
 resolveField fallback lh selection@(AST.SelectionField field) = do
   let fieldExecutor = buildFieldResolver @m @a lh selection
   case fieldExecutor of

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -324,7 +324,7 @@ instance forall m typeName interfaces fields rest.
          , MonadThrow m
          , RunFields m (RunFieldsType m fields)
          , KnownSymbol typeName
-         ) => RunUnion m ((Object typeName interfaces fields) :<|> rest) where
+         ) => RunUnion m (Object typeName interfaces fields :<|> rest) where
   runUnion (lh :<|> rh) fragment@(AST.SelectionInlineFragment (AST.InlineFragment (AST.NamedType queryTypeName) [] subSelection))
     | typeName == queryTypeName = do
         result <- buildResolver @m @(Object typeName interfaces fields) lh subSelection
@@ -342,7 +342,7 @@ instance forall m typeName interfaces fields.
          , MonadThrow m
          , RunFields m (RunFieldsType m fields)
          , KnownSymbol typeName
-         ) => RunUnion m ((Object typeName interfaces fields)) where
+         ) => RunUnion m (Object typeName interfaces fields) where
   runUnion lh fragment@(AST.SelectionInlineFragment (AST.InlineFragment (AST.NamedType queryTypeName) [] subSelection))
     | typeName == queryTypeName = do
         result <- buildResolver @m @(Object typeName interfaces fields) lh subSelection

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -261,7 +261,7 @@ instance forall ks t m.
   runFields lh selection@(AST.SelectionField field) = do
     let fieldExecutor = buildFieldResolver @m @(Field ks t) lh selection
     objectField <- executeNamedField @m field fieldExecutor
-    maybe (queryError ("Query for undefined selection:" <> show selection)) pure objectField
+    maybe (queryError ("Query for undefined selection: " <> show selection)) pure objectField
   runFields _ f = queryError ("Unexpected Selection value. Is the query normalized?: " <> show f)
 
 instance forall m a b.
@@ -273,7 +273,7 @@ instance forall m a b.
   runFields lh selection@(AST.SelectionField field) = do
     let fieldExecutor = buildFieldResolver @m @(a :> b) lh selection
     objectField <- executeNamedField @m field fieldExecutor
-    maybe (queryError ("Query for undefined selection:" <> show selection)) pure objectField
+    maybe (queryError ("Query for undefined selection: " <> show selection)) pure objectField
   runFields _ f = queryError ("Unexpected Selection value. Is the query normalized?: " <> show f)
 
 

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -65,7 +65,7 @@ instance Arbitrary Name where
 -- >>> makeName "9-bar"
 -- Nothing
 makeName :: Text -> Maybe Name
-makeName = map Name . hush . parseOnly AST.pName
+makeName = map Name . hush . parseOnly AST.nameParser
 
 -- | Create a 'Name', panicking if the given text is invalid.
 --

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -33,7 +33,7 @@ import Data.Aeson (ToJSON(..), (.=), pairs)
 import qualified Data.Aeson as Aeson
 import Data.Attoparsec.Text (parseOnly)
 import qualified Data.Map as Map
-import qualified GraphQL.Internal.Parser as Parser
+import qualified GraphQL.Internal.AST as AST
 import Test.QuickCheck (Arbitrary(..), elements, oneof, listOf)
 
 import qualified GraphQL.Internal.AST as AST
@@ -65,7 +65,7 @@ instance Arbitrary Name where
 -- >>> makeName "9-bar"
 -- Nothing
 makeName :: Text -> Maybe Name
-makeName = map Name . hush . parseOnly Parser.name
+makeName = map Name . hush . parseOnly AST.pName
 
 -- | Create a 'Name', panicking if the given text is invalid.
 --

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -60,3 +60,10 @@ tests = testSpec "TypeAPI" $ do
       let wrongQuery = getQuery "{ not_a_field }"
       caught <- (runQuery wrongQuery >> pure Nothing) `catch` \(e :: QueryError) -> pure (Just e)
       caught `shouldBe` Just (QueryError "Query for undefined selection: SelectionField (Field \"\" \"not_a_field\" [] [] [])")
+    it "complains about missing argument" $ do
+      let wrongQuery = getQuery "{ t }"
+      caught <- (runQuery wrongQuery >> pure Nothing) `catch` \(e :: QueryError) -> pure (Just e)
+      -- TODO: jml thinks this should be Just (QueryError "Value missing: x"),
+      -- but exercising current behaviour is an improvement, even if it just
+      -- helps us understand what all this code does.
+      caught `shouldBe` Just (QueryError "Query for undefined selection: SelectionField (Field \"\" \"t\" [] [] [])")

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -19,6 +19,7 @@ import GraphQL.Server
   , (:<>)(..)
   )
 import qualified GraphQL.Internal.AST as AST
+import GraphQL.Value (Value)
 import Data.Aeson (encode)
 
 import GraphQL.Internal.Parser (document)
@@ -27,35 +28,35 @@ import Data.Attoparsec.Text (parseOnly, endOfInput)
 -- Test a custom error monad
 -- TODO: I didn't realize that MonadThrow throws in the base monad (IO).
 type TMonad = ExceptT Text IO
-type T = Object "T" '[] '[Field "z" Int32, Argument "t" Int32 :> Field "t" Int32]
+type T = Object "T" '[] '[ Field "z" Int32
+                         , Argument "x" Int32 :> Field "t" Int32
+                         , Argument "y" Int32 :> Field "q" Int32
+                         ]
 
 tHandler :: Handler TMonad T
 tHandler =
-  pure $ (pure 10) :<> (\tArg -> pure tArg)
+  pure $ (pure 10) :<> (\tArg -> pure tArg) :<> (pure . (*2))
 
-
-tQuery :: AST.SelectionSet
-tQuery =
+getQuery :: Text -> AST.SelectionSet
+getQuery query =
   let Right (AST.Document [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
-        parseOnly (document <* endOfInput) "{ t(t: 12) }"
+        parseOnly (document <* endOfInput) query
   in selectionSet
 
-tWrongQuery :: AST.SelectionSet
-tWrongQuery =
-  let Right (AST.Document [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
-        parseOnly (document <* endOfInput) "{ not_a_field }"
-  in selectionSet
-
+runQuery :: AST.SelectionSet -> IO (Either Text Value)
+runQuery query = runExceptT (buildResolver @TMonad @T tHandler query)
 
 tests :: IO TestTree
-tests = testSpec "Type" $ do
+tests = testSpec "TypeAPI" $ do
   describe "tTest" $ do
     it "works in a simple case" $ do
-      Right r <- runExceptT $ buildResolver @TMonad @T tHandler tQuery
+      let query = getQuery "{ t(x: 12) }"
+      Right r <- runQuery query
       encode r `shouldBe` "{\"t\":12}"
-    it "complains on error" $ do
+    it "complains about missing field" $ do
       -- TODO: Apparently MonadThrow throws in the *base monad*,
       -- i.e. usually IO. If we want to throw in the wrapper monad I
       -- think we may need to use MonadFail??
-      caught <- (runExceptT (buildResolver @TMonad @T tHandler tWrongQuery) >> pure Nothing) `catch` \(e :: QueryError) -> pure (Just e)
-      caught `shouldBe` Just (QueryError "Query for undefined selection:SelectionField (Field \"\" \"not_a_field\" [] [] [])")
+      let wrongQuery = getQuery "{ not_a_field }"
+      caught <- (runQuery wrongQuery >> pure Nothing) `catch` \(e :: QueryError) -> pure (Just e)
+      caught `shouldBe` Just (QueryError "Query for undefined selection: SelectionField (Field \"\" \"not_a_field\" [] [] [])")

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -1,13 +1,22 @@
+{-# LANGUAGE TypeApplications #-}
+
 -- | Tests for query validation.
 module ValidationTests (tests) where
 
 import Protolude
 
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck ((===))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import qualified GraphQL.Internal.AST as AST
-import GraphQL.Internal.Validation (ValidationError(..), getErrors)
+import GraphQL.Internal.Validation
+  ( ValidationError(..)
+  , findDuplicates
+  , getErrors
+  )
+
 
 tests :: IO TestTree
 tests = testSpec "Validation" $ do
@@ -42,3 +51,16 @@ tests = testSpec "Validation" $ do
                   )
                 ]
       getErrors doc `shouldBe` [DuplicateOperation "me"]
+
+  describe "findDuplicates" $ do
+    prop "returns empty on unique lists" $ do
+      \xs -> findDuplicates @Int (ordNub xs) === []
+    prop "finds only duplicates" $ \xs -> do
+      all (>1) (count xs <$> findDuplicates @Int xs)
+    prop "finds all duplicates" $ \xs -> do
+      (sort . findDuplicates @Int) xs === (ordNub . sort . filter ((> 1) . count xs)) xs
+
+
+-- | Count the number of times 'x' occurs in 'xs'.
+count :: Eq a => [a] -> a -> Int
+count xs x = (length . filter (== x)) xs

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -2,9 +2,9 @@ module ValueTests (tests) where
 
 import Protolude
 
+import Test.Hspec.QuickCheck (prop)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
-import Test.Hspec.QuickCheck (prop)
 
 import GraphQL.Value
   ( Object(..)


### PR DESCRIPTION
Sorry, this is a bit of a mixed bag of changes that I've been working on in my spare time over the last few weeks. I figure I'd better get them in now, even though none of them are exactly whole changes.

* quickcheck tests for `findDuplicates`, because it's always worth checking
* benchmarks for `findDuplicates`. we don't care about it quite so much, but it's nice to start with _something_
* move all the name parsing machinery to the `AST` module in preparation for changing the `Name` type
* add a bunch of tests to show how the parser behaves (this is my equivalent of @teh pasting stuff into a repl)
* change `buildFieldResolver` to return an explicit error via `Either` if it somehow matches on the wrong pattern
* extract common code from the `RunFields` type class. At this point, the implementations only differ in how they fallback if there's no match and what type variables they use. I speculate that we might be able to tighten up the typeclass definition so they just provide those.
* tidy of the TypeApiTests so they duplicate less code and provide a slightly more functional working example of using the API. (I guess we should rename this module).
