### PR TITLE
Guaranteed correct name in AST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/.stack-work
+.stack-work

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -213,7 +213,13 @@ builtinType = pure . TypeNonNull . NonNullTypeNamed . BuiltinType
 -- a great deal of duplication by making HasAnnotatedType a parametrised type
 -- class.
 
+-- TODO(jml): Be smarter and figure out how to say "all integral types" rather
+-- than listing each individually.
+
 instance HasAnnotatedType Int where
+  getAnnotatedType = builtinType GInt
+
+instance HasAnnotatedType Int32 where
   getAnnotatedType = builtinType GInt
 
 instance HasAnnotatedType Bool where
@@ -261,6 +267,9 @@ builtinInputType :: Builtin -> Either NameError (AnnotatedType InputType)
 builtinInputType = pure . TypeNonNull . NonNullTypeNamed . BuiltinInputType
 
 instance HasAnnotatedInputType Int where
+  getAnnotatedInputType = builtinInputType GInt
+
+instance HasAnnotatedInputType Int32 where
   getAnnotatedInputType = builtinInputType GInt
 
 instance HasAnnotatedInputType Bool where

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -16,11 +16,13 @@ module GraphQL.API
   , GraphQLEnum(..)
   , Interface
   , (:>)(..)
+  , HasAnnotatedType(..)
+  , HasAnnotatedInputType
+  , HasObjectDefinition(..)
+  , getArgumentDefinition
   -- | Exported for testing. Perhaps should be a different module.
   , getFieldDefinition
-  , getDefinition
   , getInterfaceDefinition
-  , getAnnotatedType
   , getAnnotatedInputType
   ) where
 

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -31,7 +31,7 @@ import qualified GraphQL.Internal.Schema (Type)
 import GHC.TypeLits (Symbol, KnownSymbol, symbolVal)
 import qualified GHC.TypeLits (TypeError, ErrorMessage(..))
 import qualified GraphQL.Value as GValue
-import GraphQL.Internal.AST (makeName)
+import GraphQL.Internal.AST (NameError, makeName)
 
 -- $setup
 -- >>> :set -XDataKinds -XTypeOperators
@@ -79,18 +79,12 @@ data Argument (name :: Symbol) (argType :: Type)
 -- https://hackage.haskell.org/package/optional-args-1.0.1)
 data DefaultArgument (name :: Symbol) (argType :: Type)
 
-
-newtype NameError = NameError Text deriving (Eq, Show)
+-- | Convert a type-level 'Symbol' into a GraphQL 'Name'.
+nameFromSymbol :: forall (n :: Symbol) (proxy :: Symbol -> *). KnownSymbol n => proxy n -> Either NameError Name
+nameFromSymbol proxy = makeName (toS (symbolVal proxy))
 
 cons :: a -> [a] -> [a]
 cons = (:)
-
--- | Convert a type-level 'Symbol' into a GraphQL 'Name'.
-nameFromSymbol :: forall (n :: Symbol) (proxy :: Symbol -> *). KnownSymbol n => proxy n -> Either NameError Name
-nameFromSymbol proxy = note (NameError name) (makeName name)
-  where
-    name = toS (symbolVal proxy)
-
 
 -- Transform into a Schema definition
 class HasObjectDefinition a where

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -28,9 +28,10 @@ import Protolude hiding (Enum)
 
 import GraphQL.Internal.Schema hiding (Type)
 import qualified GraphQL.Internal.Schema (Type)
-import GHC.TypeLits (Symbol, KnownSymbol, symbolVal)
+import GHC.TypeLits (Symbol, KnownSymbol)
 import qualified GHC.TypeLits (TypeError, ErrorMessage(..))
 import qualified GraphQL.Value as GValue
+import GraphQL.Internal.AST (unsafeNameFromSymbol)
 
 -- $setup
 -- >>> :set -XDataKinds -XTypeOperators
@@ -93,7 +94,7 @@ class HasFieldDefinitions a where
   getFieldDefinitions :: [FieldDefinition]
 
 instance forall a as. (HasFieldDefinition a, HasFieldDefinitions as) => HasFieldDefinitions (a:as) where
-  getFieldDefinitions = (getFieldDefinition @a):(getFieldDefinitions @as)
+  getFieldDefinitions = getFieldDefinition @a:getFieldDefinitions @as
 
 instance HasFieldDefinitions '[] where
   getFieldDefinitions = []
@@ -113,17 +114,10 @@ class UnionTypeObjectTypeDefinitionList a where
   getUnionTypeObjectTypeDefinitions :: [ObjectTypeDefinition]
 
 instance forall a as. (HasObjectDefinition a, UnionTypeObjectTypeDefinitionList as) => UnionTypeObjectTypeDefinitionList (a:as) where
-  getUnionTypeObjectTypeDefinitions = (getDefinition @a):(getUnionTypeObjectTypeDefinitions @as)
+  getUnionTypeObjectTypeDefinitions = getDefinition @a:getUnionTypeObjectTypeDefinitions @as
 
 instance UnionTypeObjectTypeDefinitionList '[] where
   getUnionTypeObjectTypeDefinitions = []
-
-
--- | Convert a type-level 'Symbol' into a GraphQL 'Name'.
---
--- Panics if the name is not valid GraphQL.
-unsafeNameFromSymbol :: forall (n :: Symbol) (proxy :: Symbol -> *). KnownSymbol n => proxy n -> Name
-unsafeNameFromSymbol = GValue.unsafeMakeName . toS . symbolVal
 
 -- Interfaces
 class HasInterfaceDefinitions a where

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -291,7 +291,6 @@ instance forall t. (HasAnnotatedInputType t) => HasAnnotatedInputType (List t) w
 
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedInputType (Enum ks enum) where
   getAnnotatedInputType = do
-    -- TODO: rewrite applicative
     let name = nameFromSymbol (Proxy :: Proxy ks)
     let et = EnumTypeDefinition <$> name <*> pure (map EnumValueDefinition (enumValues @enum))
     TypeNonNull . NonNullTypeNamed . DefinedInputType . InputTypeDefinitionEnum <$> et

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -4,10 +4,10 @@
 module GraphQL.Internal.AST
   ( Name(getNameText)
   , NameError
+  , formatNameError
   , nameParser
   , makeName
   , unsafeMakeName
-  , unsafeNameFromSymbol
   , Document(..)
   , Definition(..)
   , OperationDefinition(..)
@@ -55,7 +55,6 @@ import Protolude hiding (Type)
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.Text as A
 import Data.Char (isDigit)
-import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Test.QuickCheck (Arbitrary(..), elements, listOf)
 
 import GraphQL.Internal.Tokens (tok)
@@ -89,6 +88,8 @@ nameParser = Name <$> tok ((<>) <$> A.takeWhile1 isA_z
 
 newtype NameError = NameError Text deriving (Eq, Show)
 
+-- TODO: error-handling: if we do go for an ADT error style, we should have a
+-- type class for pretty-printing errors. See jml/graphql-api#20.
 formatNameError :: NameError -> Text
 formatNameError (NameError name) = "Not a valid GraphQL name: " <> show name
 
@@ -115,13 +116,6 @@ unsafeMakeName name =
   case makeName name of
     Left e -> panic (formatNameError e)
     Right n -> n
-
--- | Convert a type-level 'Symbol' into a GraphQL 'Name'.
---
--- Panics if the name is not valid GraphQL.
-unsafeNameFromSymbol :: forall (n :: Symbol) (proxy :: Symbol -> *). KnownSymbol n => proxy n -> Name
-unsafeNameFromSymbol = unsafeMakeName . toS . symbolVal
-
 
 -- * Document
 

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -101,7 +101,7 @@ formatNameError (NameError name) = "Not a valid GraphQL name: " <> show name
 -- >>> makeName "foo"
 -- Right (Name {getNameText = "foo"})
 -- >>> makeName "9-bar"
--- NameError "9-bar"
+-- Left (NameError "9-bar")
 makeName :: Text -> Either NameError Name
 makeName name = first (const (NameError name)) (A.parseOnly nameParser name)
 

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 module GraphQL.Internal.AST
-  ( Name(getName)
+  ( Name(getNameText)
   , nameParser
   , makeName
   , unsafeMakeName
@@ -64,10 +64,10 @@ import GraphQL.Internal.Tokens (tok)
 -- | A name in GraphQL.
 --
 -- https://facebook.github.io/graphql/#sec-Names
-newtype Name = Name { getName :: Text } deriving (Eq, Ord, Show)
+newtype Name = Name { getNameText :: Text } deriving (Eq, Ord, Show)
 
 instance Aeson.ToJSON Name where
-  toJSON = Aeson.toJSON . getName
+  toJSON = Aeson.toJSON . getNameText
 
 instance Arbitrary Name where
   arbitrary = do
@@ -92,7 +92,7 @@ nameParser = Name <$> tok ((<>) <$> A.takeWhile1 isA_z
 -- not match, return Nothing.
 --
 -- >>> makeName "foo"
--- Just (Name {getName = "foo"})
+-- Just (Name {getNameText = "foo"})
 -- >>> makeName "9-bar"
 -- Nothing
 makeName :: Text -> Maybe Name
@@ -103,7 +103,7 @@ makeName = hush . A.parseOnly nameParser
 -- Prefer 'makeName' to this in all cases.
 --
 -- >>> unsafeMakeName "foo"
--- Name {getName = "foo"}
+-- Name {getNameText = "foo"}
 unsafeMakeName :: Text -> Name
 unsafeMakeName name = fromMaybe (panic $ "Not a valid GraphQL name: " <> show name) (makeName name)
 

--- a/src/GraphQL/Internal/Encoder.hs
+++ b/src/GraphQL/Internal/Encoder.hs
@@ -165,8 +165,8 @@ fieldDefinitions = bracesCommas fieldDefinition
 fieldDefinition :: AST.FieldDefinition -> Text
 fieldDefinition (AST.FieldDefinition name args ty) =
   AST.getNameText name <> optempty argumentsDefinition args
-                   <> ":"
-                   <> type_ ty
+                       <> ":"
+                       <> type_ ty
 
 argumentsDefinition :: AST.ArgumentsDefinition -> Text
 argumentsDefinition = parensCommas inputValueDefinition

--- a/src/GraphQL/Internal/Encoder.hs
+++ b/src/GraphQL/Internal/Encoder.hs
@@ -27,7 +27,7 @@ operationDefinition (AST.Mutation n) = "mutation " <> node n
 
 node :: AST.Node -> Text
 node (AST.Node name vds ds ss) =
-     name
+     maybe mempty AST.getName name
   <> optempty variableDefinitions vds
   <> optempty directives ds
   <> selectionSet ss
@@ -43,7 +43,7 @@ defaultValue :: AST.DefaultValue -> Text
 defaultValue val = "=" <> value val
 
 variable :: AST.Variable -> Text
-variable (AST.Variable name) = "$" <> name
+variable (AST.Variable name) = "$" <> AST.getName name
 
 selectionSet :: AST.SelectionSet -> Text
 selectionSet = bracesCommas selection
@@ -55,8 +55,8 @@ selection (AST.SelectionFragmentSpread x) = fragmentSpread x
 
 field :: AST.Field -> Text
 field (AST.Field alias name args ds ss) =
-       optempty (`snoc` ':') alias
-    <> name
+       optempty (`snoc` ':') (maybe mempty AST.getName alias)
+    <> AST.getName name
     <> optempty arguments args
     <> optempty directives ds
     <> optempty selectionSet ss
@@ -65,23 +65,23 @@ arguments :: [AST.Argument] -> Text
 arguments = parensCommas argument
 
 argument :: AST.Argument -> Text
-argument (AST.Argument name v) = name <> ":" <> value v
+argument (AST.Argument name v) = AST.getName name <> ":" <> value v
 
 -- * Fragments
 
 fragmentSpread :: AST.FragmentSpread -> Text
 fragmentSpread (AST.FragmentSpread name ds) =
-  "..." <> name <> optempty directives ds
+  "..." <> AST.getName name <> optempty directives ds
 
 inlineFragment :: AST.InlineFragment -> Text
 inlineFragment (AST.InlineFragment (AST.NamedType tc) ds ss) =
-  "... on " <> tc
+  "... on " <> AST.getName tc
             <> optempty directives ds
             <> optempty selectionSet ss
 
 fragmentDefinition :: AST.FragmentDefinition -> Text
 fragmentDefinition (AST.FragmentDefinition name (AST.NamedType tc) ds ss) =
-  "fragment " <> name <> " on " <> tc
+  "fragment " <> AST.getName name <> " on " <> AST.getName tc
               <> optempty directives ds
               <> selectionSet ss
 
@@ -95,7 +95,7 @@ value (AST.ValueInt      x) = pack $ show x
 value (AST.ValueFloat    x) = pack $ show x
 value (AST.ValueBoolean  x) = booleanValue x
 value (AST.ValueString   x) = stringValue x
-value (AST.ValueEnum     x) = x
+value (AST.ValueEnum     x) = AST.getName x
 value (AST.ValueList     x) = listValue x
 value (AST.ValueObject   x) = objectValue x
 
@@ -114,7 +114,7 @@ objectValue :: AST.ObjectValue -> Text
 objectValue (AST.ObjectValue ofs) = bracesCommas objectField ofs
 
 objectField :: AST.ObjectField -> Text
-objectField (AST.ObjectField name v) = name <> ":" <> value v
+objectField (AST.ObjectField name v) = AST.getName name <> ":" <> value v
 
 -- * Directives
 
@@ -122,23 +122,23 @@ directives :: [AST.Directive] -> Text
 directives = spaces directive
 
 directive :: AST.Directive -> Text
-directive (AST.Directive name args) = "@" <> name <> optempty arguments args
+directive (AST.Directive name args) = "@" <> AST.getName name <> optempty arguments args
 
 -- * Type Reference
 
 type_ :: AST.Type -> Text
-type_ (AST.TypeNamed (AST.NamedType x)) = x
+type_ (AST.TypeNamed (AST.NamedType x)) = AST.getName x
 type_ (AST.TypeList x) = listType x
 type_ (AST.TypeNonNull x) = nonNullType x
 
 namedType :: AST.NamedType -> Text
-namedType (AST.NamedType name) = name
+namedType (AST.NamedType name) = AST.getName name
 
 listType :: AST.ListType -> Text
 listType (AST.ListType ty) = brackets (type_ ty)
 
 nonNullType :: AST.NonNullType -> Text
-nonNullType (AST.NonNullTypeNamed (AST.NamedType x)) = x <> "!"
+nonNullType (AST.NonNullTypeNamed (AST.NamedType x)) = AST.getName x <> "!"
 nonNullType (AST.NonNullTypeList  x) = listType x <> "!"
 
 typeDefinition :: AST.TypeDefinition -> Text
@@ -152,7 +152,7 @@ typeDefinition (AST.TypeDefinitionTypeExtension x) = typeExtensionDefinition x
 
 objectTypeDefinition :: AST.ObjectTypeDefinition -> Text
 objectTypeDefinition (AST.ObjectTypeDefinition name ifaces fds) =
-  "type " <> name
+  "type " <> AST.getName name
           <> optempty (spaced . interfaces) ifaces
           <> optempty fieldDefinitions fds
 
@@ -164,45 +164,45 @@ fieldDefinitions = bracesCommas fieldDefinition
 
 fieldDefinition :: AST.FieldDefinition -> Text
 fieldDefinition (AST.FieldDefinition name args ty) =
-  name <> optempty argumentsDefinition args
-       <> ":"
-       <> type_ ty
+  AST.getName name <> optempty argumentsDefinition args
+                   <> ":"
+                   <> type_ ty
 
 argumentsDefinition :: AST.ArgumentsDefinition -> Text
 argumentsDefinition = parensCommas inputValueDefinition
 
 interfaceTypeDefinition :: AST.InterfaceTypeDefinition -> Text
 interfaceTypeDefinition (AST.InterfaceTypeDefinition name fds) =
-  "interface " <> name <> fieldDefinitions fds
+  "interface " <> AST.getName name <> fieldDefinitions fds
 
 unionTypeDefinition :: AST.UnionTypeDefinition -> Text
 unionTypeDefinition (AST.UnionTypeDefinition name ums) =
-  "union " <> name <> "=" <> unionMembers ums
+  "union " <> AST.getName name <> "=" <> unionMembers ums
 
 unionMembers :: [AST.NamedType] -> Text
 unionMembers = intercalate "|" . fmap namedType
 
 scalarTypeDefinition :: AST.ScalarTypeDefinition -> Text
-scalarTypeDefinition (AST.ScalarTypeDefinition name) = "scalar " <> name
+scalarTypeDefinition (AST.ScalarTypeDefinition name) = "scalar " <> AST.getName name
 
 enumTypeDefinition :: AST.EnumTypeDefinition -> Text
 enumTypeDefinition (AST.EnumTypeDefinition name evds) =
-  "enum " <> name
+  "enum " <> AST.getName name
           <> bracesCommas enumValueDefinition evds
 
 enumValueDefinition :: AST.EnumValueDefinition -> Text
-enumValueDefinition (AST.EnumValueDefinition name) = name
+enumValueDefinition (AST.EnumValueDefinition name) = AST.getName name
 
 inputObjectTypeDefinition :: AST.InputObjectTypeDefinition -> Text
 inputObjectTypeDefinition (AST.InputObjectTypeDefinition name ivds) =
-  "input " <> name <> inputValueDefinitions ivds
+  "input " <> AST.getName name <> inputValueDefinitions ivds
 
 inputValueDefinitions :: [AST.InputValueDefinition] -> Text
 inputValueDefinitions = bracesCommas inputValueDefinition
 
 inputValueDefinition :: AST.InputValueDefinition -> Text
 inputValueDefinition (AST.InputValueDefinition name ty dv) =
-  name <> ":" <> type_ ty <> maybe mempty defaultValue dv
+  AST.getName name <> ":" <> type_ ty <> maybe mempty defaultValue dv
 
 typeExtensionDefinition :: AST.TypeExtensionDefinition -> Text
 typeExtensionDefinition (AST.TypeExtensionDefinition otd) =

--- a/src/GraphQL/Internal/Output.hs
+++ b/src/GraphQL/Internal/Output.hs
@@ -12,10 +12,10 @@ import Data.List.NonEmpty (NonEmpty)
 import GraphQL.Value
   ( Object
   , objectFromList
-  , unsafeMakeName
   , ToValue(..)
   , Value(ValueObject, ValueNull)
   )
+import GraphQL.Internal.AST (unsafeMakeName)
 
 -- | GraphQL response.
 --

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -37,7 +37,7 @@ document = whiteSpace
   <|> (AST.Document . pure
         . AST.DefinitionOperation
         . AST.Query
-        . AST.Node mempty empty empty
+        . AST.Node empty empty empty
         <$> selectionSet)
   <?> "document error!"
 
@@ -54,7 +54,7 @@ operationDefinition =
   <?> "operationDefinition error!"
 
 node :: Parser AST.Node
-node = AST.Node <$> AST.nameParser
+node = AST.Node <$> (pure <$> AST.nameParser)
                 <*> optempty variableDefinitions
                 <*> optempty directives
                 <*> selectionSet
@@ -86,7 +86,7 @@ selection = AST.SelectionField <$> field
         <?> "selection error!"
 
 field :: Parser AST.Field
-field = AST.Field <$> optempty alias
+field = AST.Field <$> option empty (pure <$> alias)
                   <*> AST.nameParser
                   <*> optempty arguments
                   <*> optempty directives
@@ -334,4 +334,3 @@ between open close p = tok open *> p <* tok close
 -- `empty` /= `pure mempty` for `Parser`.
 optempty :: Monoid a => Parser a -> Parser a
 optempty = option mempty
-

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -64,7 +64,7 @@ validate :: Alternative m => AST.Document -> m ValidDocument
 validate = pure . Valid
 
 data ValidationError
-  = DuplicateOperation AST.Name
+  = DuplicateOperation (Maybe AST.Name)
   deriving (Eq, Show)
 
 

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -221,6 +221,7 @@ instance forall ks t m. (KnownSymbol ks, HasGraph m t, MonadThrow m, MonadIO m) 
     Left (QueryError ("buildFieldResolver got non AST.Field" <> show f <> ", query probably not normalized"))
 
 
+-- TODO: Remove all unsafeNameFromSymbol and replace with getName on schema values
 instance forall ks t f m. (MonadThrow m, KnownSymbol ks, BuildFieldResolver m f, ReadValue t) => BuildFieldResolver m (Argument ks t :> f) where
   buildFieldResolver handler selection@(AST.SelectionField (AST.Field _ _ arguments _ _)) =
     let argName = AST.unsafeNameFromSymbol (Proxy :: Proxy ks)

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -95,7 +95,7 @@ class ReadValue a where
   -- values for certain cases. E.g. there is an instance for @@Maybe a@@
   -- that returns Nothing if the value is missing.
   valueMissing :: AST.Name -> Either Text a
-  valueMissing name' = Left ("Value missing: " <> AST.getName name')
+  valueMissing name' = Left ("Value missing: " <> AST.getNameText name')
 
 
 -- TODO not super hot on individual values having to be instances of

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -9,8 +9,6 @@ module GraphQL.Value
   , ToValue(..)
   , valueToAST
   , Name
-  , makeName
-  , unsafeMakeName
   , List
   , String(..)
     -- * Objects
@@ -31,50 +29,11 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.String
 import Data.Aeson (ToJSON(..), (.=), pairs)
 import qualified Data.Aeson as Aeson
-import Data.Attoparsec.Text (parseOnly)
 import qualified Data.Map as Map
+import Test.QuickCheck (Arbitrary(..), oneof, listOf)
+
+import GraphQL.Internal.AST (Name(..))
 import qualified GraphQL.Internal.AST as AST
-import Test.QuickCheck (Arbitrary(..), elements, oneof, listOf)
-
-import qualified GraphQL.Internal.AST as AST
-
--- | A name in GraphQL.
---
--- https://facebook.github.io/graphql/#sec-Names
-newtype Name = Name { getName :: Text } deriving (Eq, Ord, Show)
-
-instance ToJSON Name where
-  toJSON = toJSON . getName
-
-instance Arbitrary Name where
-  arbitrary = do
-    initial <- elements alpha
-    rest <- listOf (elements (alpha <> numeric))
-    pure (unsafeMakeName (toS (initial:rest)))
-    where
-      alpha = ['A'..'Z'] <> ['a'..'z'] <> ['_']
-      numeric = ['0'..'9']
-
--- | Create a 'Name'.
---
--- Names must match the regex @[_A-Za-z][_0-9A-Za-z]*@. If the given text does
--- not match, return Nothing.
---
--- >>> makeName "foo"
--- Just (Name {getName = "foo"})
--- >>> makeName "9-bar"
--- Nothing
-makeName :: Text -> Maybe Name
-makeName = map Name . hush . parseOnly AST.nameParser
-
--- | Create a 'Name', panicking if the given text is invalid.
---
--- Prefer 'makeName' to this in all cases.
---
--- >>> unsafeMakeName "foo"
--- Name {getName = "foo"}
-unsafeMakeName :: Text -> Name
-unsafeMakeName name = fromMaybe (panic $ "Not a valid GraphQL name: " <> show name) (makeName name)
 
 -- | Concrete GraphQL value. Essentially Data.GraphQL.AST.Value, but without
 -- the "variable" field.
@@ -225,9 +184,9 @@ valueToAST (ValueInt x) = pure $ AST.ValueInt x
 valueToAST (ValueFloat x) = pure $ AST.ValueFloat x
 valueToAST (ValueBoolean x) = pure $ AST.ValueBoolean x
 valueToAST (ValueString (String x)) = pure $ AST.ValueString (AST.StringValue x)
-valueToAST (ValueEnum x) = pure $ AST.ValueEnum (getName x)
+valueToAST (ValueEnum x) = pure $ AST.ValueEnum x
 valueToAST (ValueList (List xs)) = AST.ValueList . AST.ListValue <$> traverse valueToAST xs
 valueToAST (ValueObject (Object fields)) = AST.ValueObject . AST.ObjectValue <$> traverse toObjectField fields
   where
-    toObjectField (ObjectField name value) = AST.ObjectField (getName name) <$> valueToAST value
+    toObjectField (ObjectField name value) = AST.ObjectField name <$> valueToAST value
 valueToAST ValueNull = empty

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -131,8 +131,8 @@ unionObjects objects = makeObject (objects >>= objectFields)
 
 instance ToJSON Object where
   -- Direct encoding to preserve order of keys / values
-  toJSON (Object xs) = toJSON (Map.fromList [(getName k, v) | ObjectField k v <- xs])
-  toEncoding (Object xs) = pairs (foldMap (\(ObjectField k v) -> toS (getName k) .= v) xs)
+  toJSON (Object xs) = toJSON (Map.fromList [(getNameText k, v) | ObjectField k v <- xs])
+  toEncoding (Object xs) = pairs (foldMap (\(ObjectField k v) -> toS (getNameText k) .= v) xs)
 
 -- | Turn a Haskell value into a GraphQL value.
 class ToValue a where

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -25,6 +25,12 @@ genASTValue = do
   v <- valueToAST <$> arbitrary
   maybe discard pure v
 
+dog :: AST.Name
+dog = AST.unsafeMakeName "dog"
+
+someName :: AST.Name
+someName = AST.unsafeMakeName "name"
+
 tests :: IO TestTree
 tests = testSpec "AST" $ do
   describe "Parser and encoder" $ do
@@ -60,9 +66,9 @@ tests = testSpec "AST" $ do
       it "parses ununusual objects" $ do
         let input = AST.ValueObject
                     (AST.ObjectValue
-                     [ AST.ObjectField "s"
+                     [ AST.ObjectField (AST.unsafeMakeName "s")
                        (AST.ValueString (AST.StringValue "\224\225v^6{FPDk\DC3\a")),
-                       AST.ObjectField "Hsr" (AST.ValueInt 0)
+                       AST.ObjectField (AST.unsafeMakeName "Hsr") (AST.ValueInt 0)
                      ])
         let output = Encoder.value input
         parseOnly Parser.value output `shouldBe` Right input
@@ -86,10 +92,10 @@ tests = testSpec "AST" $ do
       let expected = AST.Document
                      [ AST.DefinitionOperation
                        (AST.Query
-                         (AST.Node "" [] []
+                         (AST.Node Nothing [] []
                            [ AST.SelectionField
-                               (AST.Field "" "dog" [] []
-                                 [ AST.SelectionField (AST.Field "" "name" [] [] [])
+                               (AST.Field Nothing dog [] []
+                                 [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                                  ])
                            ]))
                      ]
@@ -113,10 +119,10 @@ tests = testSpec "AST" $ do
       let expected = AST.Document
                      [ AST.DefinitionOperation
                          (AST.Query
-                           (AST.Node "" [] []
+                           (AST.Node Nothing [] []
                             [ AST.SelectionField
-                                (AST.Field "" "dog" [] []
-                                  [ AST.SelectionField (AST.Field "" "name" [] [] [])
+                                (AST.Field Nothing dog [] []
+                                  [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                                   ])
                             ]))
                      ]
@@ -134,18 +140,18 @@ tests = testSpec "AST" $ do
       let expected = AST.Document
                      [ AST.DefinitionOperation
                          (AST.Query
-                           (AST.Node "houseTrainedQuery"
+                           (AST.Node (Just (AST.unsafeMakeName "houseTrainedQuery"))
                             [ AST.VariableDefinition
-                                (AST.Variable "atOtherHomes")
-                                (AST.TypeNamed (AST.NamedType "Boolean"))
+                                (AST.Variable (AST.unsafeMakeName "atOtherHomes"))
+                                (AST.TypeNamed (AST.NamedType (AST.unsafeMakeName "Boolean")))
                                 (Just (AST.ValueBoolean True))
                             ] []
                             [ AST.SelectionField
-                                (AST.Field "" "dog" [] []
+                                (AST.Field Nothing dog [] []
                                  [ AST.SelectionField
-                                     (AST.Field "" "isHousetrained"
-                                      [ AST.Argument "atOtherHomes"
-                                          (AST.ValueVariable (AST.Variable "atOtherHomes"))
+                                     (AST.Field Nothing (AST.unsafeMakeName "isHousetrained")
+                                      [ AST.Argument (AST.unsafeMakeName "atOtherHomes")
+                                          (AST.ValueVariable (AST.Variable (AST.unsafeMakeName "atOtherHomes")))
                                       ] [] [])
                                  ])
                             ]))

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -95,38 +95,37 @@ tests :: IO TestTree
 tests = testSpec "Type" $ do
   describe "Field" $
     it "encodes correctly" $ do
-    getFieldDefinition @(Field "hello" Int) `shouldBe` FieldDefinition (unsafeMakeName "hello") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GInt)))
+    getFieldDefinition @(Field "hello" Int) `shouldBe` Right (FieldDefinition (unsafeMakeName "hello") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GInt))))
   describe "Interface" $
     it "encodes correctly" $ do
     getInterfaceDefinition @Sentient `shouldBe`
-      InterfaceTypeDefinition
+      Right (InterfaceTypeDefinition
         (unsafeMakeName "Sentient")
-        (NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
+        (NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))]))
   describe "full example" $
     it "encodes correctly" $ do
     getDefinition @Human `shouldBe`
-      ObjectTypeDefinition (unsafeMakeName "Human")
+      Right (ObjectTypeDefinition (unsafeMakeName "Human")
         [ InterfaceTypeDefinition (unsafeMakeName "Sentient") (
             NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
         ]
-        (NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))])
+        (NonEmptyList [FieldDefinition (unsafeMakeName "name") [] (TypeNonNull (NonNullTypeNamed (BuiltinType GString)))]))
   describe "output Enum" $
     it "encodes correctly" $ do
     getAnnotatedType @DogCommand `shouldBe`
-       TypeNonNull (NonNullTypeNamed (DefinedType (TypeDefinitionEnum (EnumTypeDefinition (unsafeMakeName "DogCommand")
+       Right (TypeNonNull (NonNullTypeNamed (DefinedType (TypeDefinitionEnum (EnumTypeDefinition (unsafeMakeName "DogCommand")
          [ EnumValueDefinition (unsafeMakeName "SIT")
          , EnumValueDefinition (unsafeMakeName "DOWN")
          , EnumValueDefinition (unsafeMakeName "HEEL")
-         ]))))
+         ])))))
   describe "Union type" $
     it "encodes correctly" $ do
     getAnnotatedType @CatOrDog `shouldBe`
-      TypeNamed (DefinedType (TypeDefinitionUnion (UnionTypeDefinition (unsafeMakeName "CatOrDog")
-        (NonEmptyList [ getDefinition @Cat
-                      , getDefinition @Dog
-                      ]
-        ))))
+      TypeNamed . DefinedType . TypeDefinitionUnion . UnionTypeDefinition (unsafeMakeName "CatOrDog")
+        . NonEmptyList <$> sequence [ getDefinition @Cat
+                                    , getDefinition @Dog
+                                    ]
   describe "List" $
     it "encodes correctly" $ do
-    getAnnotatedType @(List Int) `shouldBe` TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinType GInt))))
-    getAnnotatedInputType @(List Int) `shouldBe` TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinInputType GInt))))
+    getAnnotatedType @(List Int) `shouldBe` Right (TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinType GInt)))))
+    getAnnotatedInputType @(List Int) `shouldBe` Right (TypeList (ListType (TypeNonNull (NonNullTypeNamed (BuiltinInputType GInt)))))

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -22,6 +22,7 @@ import GraphQL.API
   , getFieldDefinition
   , getInterfaceDefinition
   )
+import GraphQL.Internal.AST (unsafeMakeName)
 import GraphQL.Internal.Schema
   ( EnumTypeDefinition(..)
   , EnumValueDefinition(..)
@@ -38,7 +39,6 @@ import GraphQL.Internal.Schema
   , Builtin(..)
   , InputType(..)
   )
-import GraphQL.Value (unsafeMakeName)
 
 -- Examples taken from the spec
 

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -17,6 +17,11 @@ import GraphQL.Internal.Validation
   , getErrors
   )
 
+me :: AST.Name
+me = AST.unsafeMakeName "me"
+
+someName :: AST.Name
+someName = AST.unsafeMakeName "name"
 
 tests :: IO TestTree
 tests = testSpec "Validation" $ do
@@ -25,8 +30,8 @@ tests = testSpec "Validation" $ do
       let doc = AST.Document
                 [ AST.DefinitionOperation
                   ( AST.Query
-                    ( AST.Node "me" [] []
-                      [ AST.SelectionField (AST.Field "name" "name" [] [] [])
+                    ( AST.Node (Just me) [] []
+                      [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                       ]
                     )
                   )
@@ -37,20 +42,20 @@ tests = testSpec "Validation" $ do
       let doc = AST.Document
                 [ AST.DefinitionOperation
                   ( AST.Query
-                    ( AST.Node "me" [] []
-                      [ AST.SelectionField (AST.Field "name" "name" [] [] [])
+                    ( AST.Node (Just me) [] []
+                      [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                       ]
                     )
                   )
                 , AST.DefinitionOperation
                   ( AST.Query
-                    ( AST.Node "me" [] []
-                      [ AST.SelectionField (AST.Field "name" "name" [] [] [])
+                    ( AST.Node (Just me) [] []
+                      [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                       ]
                     )
                   )
                 ]
-      getErrors doc `shouldBe` [DuplicateOperation "me"]
+      getErrors doc `shouldBe` [DuplicateOperation (Just me)]
 
   describe "findDuplicates" $ do
     prop "returns empty on unique lists" $ do

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -6,10 +6,10 @@ import Test.Hspec.QuickCheck (prop)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
 
+import GraphQL.Internal.AST (unsafeMakeName)
 import GraphQL.Value
   ( Object(..)
   , ObjectField(..)
-  , unsafeMakeName
   , unionObjects
   , objectFromList
   , toValue


### PR DESCRIPTION
* Move all the name stuff from `Value` to `AST`
* Guarantee that only valid names ever appear in the `AST` or anywhere else
* Add a `HasName` type class that is implemented by all named things in the schema (can be extended to other things later, this is just the only place I needed it)
* Change the `getFooDefinition` methods to return `Either NameError Foo`. This involves changing most of the code to be applicative, which in turn involves a fair chunk of using the composition operator. Sorry.
* While doing that, removed some duplication (mostly because it was less boring than typing the same thing twice)
* Update Server module to use the API module and to get names from there, rather than directly from symbols. This simplifies some of the types (but I tried to tread lightly here). Dodgy names are now thrown as `QueryError`. I think we can do better than this, but await your error handling branch.

New TODOs:

```haskell
src/GraphQL/API.hs:
  -- TODO(jml): Given that AnnotatedType is parametrised, we can probably reduce
  -- a great deal of duplication by making HasAnnotatedType a parametrised type
  -- class.

src/GraphQL/API.hs:
  -- TODO(jml): Be smarter and figure out how to say "all integral types" rather
  -- than listing each individually.

src/GraphQL/Server.hs:
  -- TODO(jml): I don't understand why I can't extract (Object typeName interfaces fields)
  -- from this Union instance as I did for the above Union instance.
```