### PR TITLE
Move error handling closer to the spec

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -65,6 +65,7 @@ test-suite graphql-api-doctests
     , doctest
   other-modules:
       ASTTests
+      Examples.FileSystem
       Examples.UnionExample
       Spec
       TypeApiTests
@@ -98,6 +99,7 @@ test-suite graphql-api-tests
   other-modules:
       ASTTests
       Doctests
+      Examples.FileSystem
       Examples.UnionExample
       TypeApiTests
       TypeTests

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.14.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -94,6 +94,7 @@ test-suite graphql-api-tests
     , raw-strings-qq
     , tasty
     , tasty-hspec
+    , directory
   other-modules:
       ASTTests
       Doctests

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ tests:
       - raw-strings-qq
       - tasty
       - tasty-hspec
+      - directory
 
   graphql-api-doctests:
     main: Doctests.hs

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -121,6 +121,10 @@ instance Defaultable Bool
 
 instance Defaultable Text
 
+instance Defaultable (Maybe a) where
+  -- | The default for @Maybe a@ is @Nothing@.
+  defaultFor _ = pure Nothing
+
 -- TODO not super hot on individual values having to be instances of
 -- HasGraph but not sure how else we can nest either types or
 -- (Object _ _ fields). Maybe instead of field we need a "SubObject"?

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -203,7 +203,7 @@ data NamedValueResolver m = NamedValueResolver AST.Name (m Result)
 -- Iterate through handlers (zipped together with their type
 -- definition) and execute handler if the name matches.
 --
--- TODO: tuple return not great (but either is wrong, too because it discards errors. Also probably need Maybe for ObjectField?
+-- TODO: tuple return not great (but either is wrong, too because it discards errors.
 type ResolveFieldResult = ([QueryError], Maybe GValue.ObjectField)
 resolveField :: forall a (m :: Type -> Type). BuildFieldResolver m a
   => FieldHandler m a -> m ResolveFieldResult -> AST.Selection -> m ResolveFieldResult
@@ -244,8 +244,8 @@ instance forall ks t m. (KnownSymbol ks, HasGraph m t, HasAnnotatedType t, Monad
     field <- first (QueryError. AST.formatNameError) (getFieldDefinition @(Field ks t))
     let name = getName field
     Right (NamedValueResolver name resolver)
-  buildFieldResolver _ _ =
-    panic "this can not happen"
+  buildFieldResolver _ f =
+    Left (InternalError ("Unexpected query selection in buildFieldResolver: " <> show f))
 
 
 instance forall ks t f m.
@@ -259,8 +259,8 @@ instance forall ks t f m.
     let argName = getName argument
     value <- first QueryError (maybe (valueMissing @t argName) (readValue @t) (lookupValue argName arguments))
     buildFieldResolver @m @f (handler value) selection
-  buildFieldResolver _ _ =
-    panic "this can not happen"
+  buildFieldResolver _ f =
+    Left (InternalError ("Unexpected query selection in buildFieldResolver: " <> show f))
 
 
 -- We only allow Field and Argument :> Field combinations:

--- a/tests/Examples/FileSystem.hs
+++ b/tests/Examples/FileSystem.hs
@@ -7,6 +7,7 @@ import Protolude hiding (Enum)
 import GraphQL.API
 import GraphQL.Server
 import qualified GraphQL.Internal.AST as AST
+import GraphQL.Value (Value)
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 import GraphQL.Internal.Parser (document)
 
@@ -50,7 +51,7 @@ root :: Handler IO Query
 root = do
   pure directory
 
-example :: IO Result
+example :: IO (Result Value)
 example = buildResolver @IO @Query root (query "{ root(path: \"/etc\") { entries { name } } }")
 
 query :: Text -> AST.SelectionSet

--- a/tests/Examples/FileSystem.hs
+++ b/tests/Examples/FileSystem.hs
@@ -5,7 +5,7 @@ module Examples.FileSystem where
 import Protolude hiding (Enum)
 
 import GraphQL.API
-import GraphQL.Resolver
+import GraphQL.Server
 import qualified GraphQL.Internal.AST as AST
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 import GraphQL.Internal.Parser (document)

--- a/tests/Examples/FileSystem.hs
+++ b/tests/Examples/FileSystem.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Examples.FileSystem where
+import Protolude hiding (Enum)
+
+import GraphQL.API
+import GraphQL.Resolver
+import qualified GraphQL.Internal.AST as AST
+import Data.Attoparsec.Text (parseOnly, endOfInput)
+import GraphQL.Internal.Parser (document)
+
+import qualified System.Directory as SD
+
+type File = Object "File" '[]
+  '[ Field "name" Text
+   , Field "absolutePath" Text
+   ]
+
+type Directory = Object "Directory" '[]
+  '[ Argument "glob" (Maybe Text) :> Field "entries" (List File)
+   , Field "numEntries" Int32
+   , Field "absolutePath" Text
+   ]
+
+type Query = Object "Query" '[]
+  '[ Argument "path" (Maybe Text) :> Field "root" Directory ]
+
+
+oneFile :: FilePath -> Handler IO File
+oneFile path =
+  pure $ pure ((toS @_ @Text) path)
+    :<> map (toS @_ @Text) (SD.canonicalizePath path)
+
+directory :: Maybe Text -> Handler IO Directory
+directory Nothing = directory (Just "/")
+directory (Just path) = do
+  paths <- SD.listDirectory (toS path)
+  pure $ filtered paths
+    :<> pure (fromIntegral (length paths))
+    :<> map (toS @_ @Text) (SD.canonicalizePath (toS path))
+    where
+      filtered :: [FilePath] -> Maybe Text -> [Handler IO File]
+      filtered paths (Just glob) =
+        map oneFile (filter (== (toS glob)) paths)
+      filtered paths Nothing =
+        map oneFile paths
+
+root :: Handler IO Query
+root = do
+  pure directory
+
+example :: IO Result
+example = buildResolver @IO @Query root (query "{ root(path: \"/etc\") { entries { name } } }")
+
+query :: Text -> AST.SelectionSet
+query q =
+  let Right (AST.Document [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
+       parseOnly (document <* endOfInput) q
+  in selectionSet

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -1,10 +1,17 @@
 {-# LANGUAGE DataKinds #-}
 module Examples.UnionExample  where
 
+-- TODO: union code is totally wrong because I misunderstood the
+-- spec. The server decides the return type and we'll probably need an
+-- open sum type for returning.
+
+{-
+
 import Protolude hiding (Enum)
 import qualified GraphQL.Internal.AST as AST
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 import GraphQL.Internal.Parser (document)
+
 
 import GraphQL.API
 import GraphQL.Server
@@ -32,3 +39,4 @@ query q =
   let Right (AST.Document [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
        parseOnly (document <* endOfInput) q
   in selectionSet
+-}

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -14,6 +14,7 @@ import qualified ValueTests
 
 -- import examples to ensure they compile
 import Examples.UnionExample ()
+import Examples.FileSystem ()
 
 main :: IO ()
 main = do

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -17,9 +17,9 @@ import GraphQL.Server
   , QueryError(..)
   , buildResolver
   , (:<>)(..)
+  , Result(..)
   )
 import qualified GraphQL.Internal.AST as AST
-import GraphQL.Value (Value)
 import Data.Aeson (encode)
 
 import GraphQL.Internal.Parser (document)
@@ -43,7 +43,7 @@ getQuery query =
         parseOnly (document <* endOfInput) query
   in selectionSet
 
-runQuery :: AST.SelectionSet -> IO (Either Text Value)
+runQuery :: AST.SelectionSet -> IO (Either Text Result)
 runQuery query = runExceptT (buildResolver @TMonad @T tHandler query)
 
 tests :: IO TestTree
@@ -51,18 +51,18 @@ tests = testSpec "TypeAPI" $ do
   describe "tTest" $ do
     it "works in a simple case" $ do
       let query = getQuery "{ t(x: 12) }"
-      Right r <- runQuery query
+      Right (Result _ r) <- runQuery query
       encode r `shouldBe` "{\"t\":12}"
     it "complains about missing field" $ do
       -- TODO: Apparently MonadThrow throws in the *base monad*,
       -- i.e. usually IO. If we want to throw in the wrapper monad I
       -- think we may need to use MonadFail??
       let wrongQuery = getQuery "{ not_a_field }"
-      caught <- (runQuery wrongQuery >> pure Nothing) `catch` \(e :: QueryError) -> pure (Just e)
+      Right (Result errs _) <- runQuery wrongQuery
       -- TODO: jml thinks this is a really bad error message. Real problem is
       -- that `not_a_field` was provided.
-      caught `shouldBe` Just (QueryError "Value missing: x")
+      errs `shouldBe` [QueryError "Value missing: x"]
     it "complains about missing argument" $ do
       let wrongQuery = getQuery "{ t }"
-      caught <- (runQuery wrongQuery >> pure Nothing) `catch` \(e :: QueryError) -> pure (Just e)
-      caught `shouldBe` Just (QueryError "Value missing: x")
+      Right (Result errs _) <- runQuery wrongQuery
+      errs `shouldBe` [QueryError "Value missing: x"]


### PR DESCRIPTION
The main change here is that instead of an `Either` we now have a `Result` which accumulates errors and values at the same time.

* This is still a draft but wanted to get your opinion early 
* I'm not super happy with `ResolveFieldResult` but not sure ATM how to phrase better (other than maybe a separate `data` type)
* MonadIO & throw are gone
* Error accumulation needs a nicer representation but a I can't tell from the [description](https://facebook.github.io/graphql/#sec-Errors) what errors for specific fields should look like.