### PR TITLE
Extract FromValue from ReadValue

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -37,6 +37,7 @@ library
     , text
   exposed-modules:
       GraphQL.API
+      GraphQL.Internal.Arbitrary
       GraphQL.Internal.AST
       GraphQL.Internal.Encoder
       GraphQL.Internal.Input

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -55,7 +55,8 @@ import Protolude hiding (Type)
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.Text as A
 import Data.Char (isDigit)
-import Test.QuickCheck (Arbitrary(..), elements, listOf)
+import qualified Data.String
+import Test.QuickCheck (Arbitrary(..), elements, listOf, oneof)
 
 import GraphQL.Internal.Tokens (tok)
 
@@ -143,6 +144,9 @@ data VariableDefinition = VariableDefinition Variable Type (Maybe DefaultValue)
 
 newtype Variable = Variable Name deriving (Eq,Show)
 
+instance Arbitrary Variable where
+  arbitrary = Variable <$> arbitrary
+
 type SelectionSet = [Selection]
 
 data Selection = SelectionField Field
@@ -185,13 +189,36 @@ data Value = ValueVariable Variable
            | ValueObject ObjectValue
              deriving (Eq,Show)
 
+instance Arbitrary Value where
+  arbitrary = oneof [ ValueVariable <$> arbitrary
+                    , ValueInt <$> arbitrary
+                    , ValueFloat <$> arbitrary
+                    , ValueBoolean <$> arbitrary
+                    , ValueString <$> arbitrary
+                    , ValueEnum <$> arbitrary
+                    , ValueList <$> arbitrary
+                    , ValueObject <$> arbitrary
+                    ]
+
 newtype StringValue = StringValue Text deriving (Eq,Show)
+
+instance Arbitrary StringValue where
+  arbitrary = StringValue . toS <$> arbitrary @Data.String.String
 
 newtype ListValue = ListValue [Value] deriving (Eq,Show)
 
+instance Arbitrary ListValue where
+  arbitrary = ListValue <$> listOf arbitrary
+
 newtype ObjectValue = ObjectValue [ObjectField] deriving (Eq,Show)
 
+instance Arbitrary ObjectValue where
+  arbitrary = ObjectValue <$> listOf arbitrary
+
 data ObjectField = ObjectField Name Value deriving (Eq,Show)
+
+instance Arbitrary ObjectField where
+  arbitrary = ObjectField <$> arbitrary <*> arbitrary
 
 type DefaultValue = Value
 

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 module GraphQL.Internal.AST
   ( Name(getNameText)
@@ -55,9 +54,9 @@ import Protolude hiding (Type)
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.Text as A
 import Data.Char (isDigit)
-import qualified Data.String
 import Test.QuickCheck (Arbitrary(..), elements, listOf, oneof)
 
+import GraphQL.Internal.Arbitrary (arbitraryText)
 import GraphQL.Internal.Tokens (tok)
 
 -- * Name
@@ -203,7 +202,7 @@ instance Arbitrary Value where
 newtype StringValue = StringValue Text deriving (Eq,Show)
 
 instance Arbitrary StringValue where
-  arbitrary = StringValue . toS <$> arbitrary @Data.String.String
+  arbitrary = StringValue <$> arbitraryText
 
 newtype ListValue = ListValue [Value] deriving (Eq,Show)
 

--- a/src/GraphQL/Internal/Arbitrary.hs
+++ b/src/GraphQL/Internal/Arbitrary.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE RankNTypes #-}
+
+module GraphQL.Internal.Arbitrary
+  ( arbitraryText
+  , arbitraryNonEmpty
+  ) where
+
+import Protolude
+
+import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty (NonEmpty)
+import qualified Data.String
+import Test.QuickCheck (Gen, Arbitrary(..), arbitrary, listOf1)
+
+-- | Generate arbitrary 'Text'.
+arbitraryText :: Gen Text
+arbitraryText = toS <$> arbitrary @Data.String.String
+
+-- | Generate an arbitrary 'NonEmpty' list.
+arbitraryNonEmpty :: forall a. Arbitrary a => Gen (NonEmpty a)
+arbitraryNonEmpty =
+  -- NonEmpty.fromList panics, but that's OK, because listOf1 is guaranteed to
+  -- return a non-empty list, and because a panic in a test is highly
+  -- informative and indicative of a bug.
+  NonEmpty.fromList <$> listOf1 arbitrary
+

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -99,7 +99,8 @@ class Defaultable a where
   defaultFor :: AST.Name -> Maybe a
   defaultFor _ = empty
 
--- | Called when we're missing a value of type @a@ with the given 'AST.Name'.
+-- | Called when the schema expects an input argument @name@ of type @a@ but
+-- @name@ has not been provided.
 valueMissing :: Defaultable a => AST.Name -> Either Text a
 valueMissing name = maybe (Left ("Value missing: " <> AST.getNameText name)) Right (defaultFor name)
 

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -106,12 +106,13 @@ class FromValue a where
 -- The default implementation is to say that there *is* no default for this
 -- type.
 class Defaultable a where
-  -- TODO: Change `valueMissing` to return a Maybe and have the error handling
-  -- magic happen a layer higher.
-  -- | valueMissing returns the value for when none is specified.
-  valueMissing :: AST.Name -> Either Text a
-  valueMissing name' = Left ("Value missing: " <> AST.getNameText name')
+  -- | defaultFor returns the value to be used when no value has been given.
+  defaultFor :: AST.Name -> Maybe a
+  defaultFor _ = empty
 
+-- | Called when we're missing a value of type @a@ with the given 'AST.Name'.
+valueMissing :: Defaultable a => AST.Name -> Either Text a
+valueMissing name = maybe (Left ("Value missing: " <> AST.getNameText name)) Right (defaultFor name)
 
 -- TODO not super hot on individual values having to be instances of
 -- HasGraph but not sure how else we can nest either types or

--- a/src/GraphQL/Server.hs
+++ b/src/GraphQL/Server.hs
@@ -144,10 +144,10 @@ instance forall m ks enum. (MonadThrow m, MonadIO m, GraphQLEnum enum) => HasGra
 -- TODO: lookup is O(N^2) in number of arguments (we linearly search
 -- each argument in the list) but considering the graphql use case
 -- where N usually < 10 this is probably OK.
-lookupValue :: AST.Name -> [AST.Argument] -> Maybe AST.Value
+lookupValue :: AST.Name -> [AST.Argument] -> Maybe GValue.Value
 lookupValue name args = case find (\(AST.Argument name' _) -> name' == name) args of
   Nothing -> Nothing
-  Just (AST.Argument _ value) -> Just value
+  Just (AST.Argument _ value) -> GValue.astToValue value
 
 
 -- TODO: variables should error, they should have been resolved already.

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -225,7 +225,10 @@ astToValue (AST.ValueBoolean x) = pure $ ValueBoolean x
 astToValue (AST.ValueString (AST.StringValue x)) = pure $ ValueString $ String x
 astToValue (AST.ValueEnum x) = pure $ ValueEnum x
 astToValue (AST.ValueList (AST.ListValue xs)) = ValueList . List <$> traverse astToValue xs
-astToValue (AST.ValueObject (AST.ObjectValue fields)) = ValueObject . Object <$> traverse toObjectField fields
+astToValue (AST.ValueObject (AST.ObjectValue fields)) = do
+  fields' <- traverse toObjectField fields
+  object <- makeObject fields'
+  pure (ValueObject object)
   where
     toObjectField (AST.ObjectField name value) = ObjectField name <$> astToValue value
 astToValue (AST.ValueVariable _) = empty

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -35,12 +35,12 @@ import Protolude
 
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.String
 import Data.Aeson (ToJSON(..), (.=), pairs)
 import qualified Data.Aeson as Aeson
 import qualified Data.Map as Map
 import Test.QuickCheck (Arbitrary(..), oneof, listOf)
 
+import GraphQL.Internal.Arbitrary (arbitraryText)
 import GraphQL.Internal.AST (Name(..))
 import qualified GraphQL.Internal.AST as AST
 
@@ -86,7 +86,7 @@ instance Arbitrary Value where
 newtype String = String Text deriving (Eq, Ord, Show)
 
 instance Arbitrary String where
-  arbitrary = String . toS <$> arbitrary @Data.String.String
+  arbitrary = String <$> arbitraryText
 
 instance ToJSON String where
   toJSON (String x) = toJSON x

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -1,17 +1,14 @@
-{-# LANGUAGE RankNTypes #-}
 module ValueTests (tests) where
 
 import Protolude
 
-import qualified Data.List.NonEmpty as NonEmpty
-import Data.List.NonEmpty (NonEmpty)
-import qualified Data.String
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Gen, Arbitrary(..), arbitrary, forAll, listOf1)
+import Test.QuickCheck (forAll)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
 
 import qualified GraphQL.Internal.AST as AST
+import GraphQL.Internal.Arbitrary (arbitraryText, arbitraryNonEmpty)
 import GraphQL.Internal.AST (unsafeMakeName)
 import GraphQL.Value
   ( Object(..)
@@ -25,16 +22,6 @@ import GraphQL.Value
   , toValue
   )
 
-
-arbitraryText :: Gen Text
-arbitraryText = toS <$> arbitrary @Data.String.String
-
-arbitraryNonEmpty :: forall a. Arbitrary a => Gen (NonEmpty a)
-arbitraryNonEmpty =
-  -- NonEmpty.fromList panics, but that's OK, because listOf1 is guaranteed to
-  -- return a non-empty list, and because a panic in a test is highly
-  -- informative and indicative of a bug.
-  NonEmpty.fromList <$> listOf1 arbitrary
 
 tests :: IO TestTree
 tests = testSpec "Value" $ do

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -6,12 +6,15 @@ import Test.Hspec.QuickCheck (prop)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
 
+import qualified GraphQL.Internal.AST as AST
 import GraphQL.Internal.AST (unsafeMakeName)
 import GraphQL.Value
   ( Object(..)
   , ObjectField(..)
+  , astToValue
   , unionObjects
   , objectFromList
+  , prop_roundtripFromAST
   , prop_roundtripFromValue
   , toValue
   )
@@ -45,6 +48,13 @@ tests = testSpec "Value" $ do
   describe "AST" $ do
     prop "Values can be converted to AST and back" $ do
       prop_roundtripFromValue
+    prop "Values can be converted from AST and back" $ do
+      prop_roundtripFromAST
+    it "Objects converted from AST have unique fields" $ do
+      let input = AST.ObjectValue [ AST.ObjectField (unsafeMakeName "foo") (AST.ValueString (AST.StringValue "bar"))
+                                  , AST.ObjectField (unsafeMakeName "foo") (AST.ValueString (AST.StringValue "qux"))
+                                  ]
+      astToValue (AST.ValueObject input) `shouldBe` Nothing
 
 
 -- | All of the fields in an object should have unique names.

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -12,6 +12,7 @@ import GraphQL.Value
   , ObjectField(..)
   , unionObjects
   , objectFromList
+  , prop_roundtripFromValue
   , toValue
   )
 
@@ -41,6 +42,9 @@ tests = testSpec "Value" $ do
   describe "Objects" $ do
     prop "have unique fields" $ do
       prop_fieldsUnique
+  describe "AST" $ do
+    prop "Values can be converted to AST and back" $ do
+      prop_roundtripFromValue
 
 
 -- | All of the fields in an object should have unique names.


### PR DESCRIPTION
We talked about this earlier, so hopefully this will be uncontroversial:

* Split `ReadValue` typeclass into one that converts values into Haskell objects (`FromValue`) and one that provides defaults (`Defaultable`)
* Change `FromValue` to operate on our "literal" values (which won't have variables, and won't have duplicate fields), rather than AST values (which can be anything that's syntactically valid)
* Change the interface for `Defaultable` to be `Maybe` rather than `Either`, since I figure the error message will always be the same, and users won't want to customise it.
* Roundtripping methods & tests 

If there are conflicts with your error branch, I'll resolve them here.