### PR TITLE
Anonymous queries

### DIFF
--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -134,16 +134,17 @@ data Definition = DefinitionOperation OperationDefinition
 -- https://facebook.github.io/graphql/#sec-Type-System
 newtype SchemaDocument = SchemaDocument [TypeDefinition] deriving (Eq, Show)
 
-data OperationDefinition = Query    { getNode :: Node }
-                         | Mutation { getNode :: Node }
-                           deriving (Eq,Show)
+data OperationDefinition
+  = Query Node
+  | Mutation Node
+  | AnonymousQuery SelectionSet
+  deriving (Eq,Show)
 
-data Node = Node (Maybe Name) [VariableDefinition] [Directive] SelectionSet
+data Node = Node Name [VariableDefinition] [Directive] SelectionSet
             deriving (Eq,Show)
 
--- XXX: Lots of things have names. Maybe we should define a typeclass for
--- getting the name?
-getNodeName :: Node -> Maybe Name
+-- TODO: Just make Node implement HasName.
+getNodeName :: Node -> Name
 getNodeName (Node name _ _ _) = name
 
 data VariableDefinition = VariableDefinition Variable Type (Maybe DefaultValue)

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -7,7 +7,8 @@ module GraphQL.Internal.AST
   , nameParser
   , makeName
   , unsafeMakeName
-  , Document(..)
+  , QueryDocument(..)
+  , SchemaDocument(..)
   , Definition(..)
   , OperationDefinition(..)
   , Node(..)
@@ -117,14 +118,21 @@ unsafeMakeName name =
     Left e -> panic (formatNameError e)
     Right n -> n
 
--- * Document
+-- * Documents
 
-newtype Document = Document { getDefinitions :: [Definition] } deriving (Eq,Show)
+-- | A 'QueryDocument' is something a user might send us.
+--
+-- https://facebook.github.io/graphql/#sec-Language.Query-Document
+newtype QueryDocument = QueryDocument { getDefinitions :: [Definition] } deriving (Eq,Show)
 
 data Definition = DefinitionOperation OperationDefinition
                 | DefinitionFragment  FragmentDefinition
-                | DefinitionType      TypeDefinition
-                  deriving (Eq,Show)
+                deriving (Eq,Show)
+
+-- | A 'SchemaDocument' is a document that defines a GraphQL schema.
+--
+-- https://facebook.github.io/graphql/#sec-Type-System
+newtype SchemaDocument = SchemaDocument [TypeDefinition] deriving (Eq, Show)
 
 data OperationDefinition = Query    { getNode :: Node }
                          | Mutation { getNode :: Node }

--- a/src/GraphQL/Internal/Encoder.hs
+++ b/src/GraphQL/Internal/Encoder.hs
@@ -1,5 +1,6 @@
 module GraphQL.Internal.Encoder
-  ( document
+  ( queryDocument
+  , schemaDocument
   , value
   ) where
 
@@ -13,13 +14,15 @@ import qualified GraphQL.Internal.AST as AST
 -- * Document
 
 -- TODO: Use query shorthand
-document :: AST.Document -> Text
-document (AST.Document defs) = (`snoc` '\n') . mconcat $ definition <$> defs
+queryDocument :: AST.QueryDocument -> Text
+queryDocument (AST.QueryDocument defs) = (`snoc` '\n') . mconcat $ definition <$> defs
 
 definition :: AST.Definition -> Text
 definition (AST.DefinitionOperation x) = operationDefinition x
 definition (AST.DefinitionFragment  x) = fragmentDefinition x
-definition (AST.DefinitionType      x) = typeDefinition x
+
+schemaDocument :: AST.SchemaDocument -> Text
+schemaDocument (AST.SchemaDocument defs) = (`snoc` '\n') . mconcat $ typeDefinition <$> defs
 
 operationDefinition :: AST.OperationDefinition -> Text
 operationDefinition (AST.Query    n) = "query "    <> node n

--- a/src/GraphQL/Internal/Encoder.hs
+++ b/src/GraphQL/Internal/Encoder.hs
@@ -13,7 +13,6 @@ import qualified GraphQL.Internal.AST as AST
 
 -- * Document
 
--- TODO: Use query shorthand
 queryDocument :: AST.QueryDocument -> Text
 queryDocument (AST.QueryDocument defs) = (`snoc` '\n') . mconcat $ definition <$> defs
 
@@ -27,10 +26,11 @@ schemaDocument (AST.SchemaDocument defs) = (`snoc` '\n') . mconcat $ typeDefinit
 operationDefinition :: AST.OperationDefinition -> Text
 operationDefinition (AST.Query    n) = "query "    <> node n
 operationDefinition (AST.Mutation n) = "mutation " <> node n
+operationDefinition (AST.AnonymousQuery ss) = selectionSet ss
 
 node :: AST.Node -> Text
 node (AST.Node name vds ds ss) =
-     maybe mempty AST.getNameText name
+     AST.getNameText name
   <> optempty variableDefinitions vds
   <> optempty directives ds
   <> selectionSet ss

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 module GraphQL.Internal.Parser
-  ( document
+  ( queryDocument
+  , schemaDocument
   , value
   ) where
 
@@ -30,21 +31,24 @@ import GraphQL.Internal.Tokens (tok, whiteSpace)
 
 -- * Document
 
-document :: Parser AST.Document
-document = whiteSpace
-   *> (AST.Document <$> many1 definition)
+queryDocument :: Parser AST.QueryDocument
+queryDocument = whiteSpace
+   *> (AST.QueryDocument <$> many1 definition)
   -- Try SelectionSet when no definition
-  <|> (AST.Document . pure
+  <|> (AST.QueryDocument . pure
         . AST.DefinitionOperation
         . AST.Query
         . AST.Node empty empty empty
         <$> selectionSet)
-  <?> "document error!"
+  <?> "query document error!"
+
+-- | Parser for a schema document.
+schemaDocument :: Parser AST.SchemaDocument
+schemaDocument = whiteSpace *> (AST.SchemaDocument <$> many1 typeDefinition) <?> "type document error"
 
 definition :: Parser AST.Definition
 definition = AST.DefinitionOperation <$> operationDefinition
          <|> AST.DefinitionFragment  <$> fragmentDefinition
-         <|> AST.DefinitionType      <$> typeDefinition
          <?> "definition error!"
 
 operationDefinition :: Parser AST.OperationDefinition

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -32,15 +32,7 @@ import GraphQL.Internal.Tokens (tok, whiteSpace)
 -- * Document
 
 queryDocument :: Parser AST.QueryDocument
-queryDocument = whiteSpace
-   *> (AST.QueryDocument <$> many1 definition)
-  -- Try SelectionSet when no definition
-  <|> (AST.QueryDocument . pure
-        . AST.DefinitionOperation
-        . AST.Query
-        . AST.Node empty empty empty
-        <$> selectionSet)
-  <?> "query document error!"
+queryDocument = whiteSpace *> (AST.QueryDocument <$> many1 definition) <?> "query document error!"
 
 -- | Parser for a schema document.
 schemaDocument :: Parser AST.SchemaDocument
@@ -55,10 +47,11 @@ operationDefinition :: Parser AST.OperationDefinition
 operationDefinition =
       AST.Query    <$ tok "query"    <*> node
   <|> AST.Mutation <$ tok "mutation" <*> node
+  <|> (AST.AnonymousQuery <$> selectionSet)
   <?> "operationDefinition error!"
 
 node :: Parser AST.Node
-node = AST.Node <$> (pure <$> AST.nameParser)
+node = AST.Node <$> AST.nameParser
                 <*> optempty variableDefinitions
                 <*> optempty directives
                 <*> selectionSet

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -63,17 +63,42 @@ newtype ValidDocument = Valid AST.QueryDocument deriving (Eq, Show)
 validate :: Alternative m => AST.QueryDocument -> m ValidDocument
 validate = pure . Valid
 
+-- | Errors arising from validating a document.
 data ValidationError
-  = DuplicateOperation (Maybe AST.Name)
+  -- | 'DuplicateOperation' means there was more than one operation defined
+  -- with the given name.
+  --
+  -- https://facebook.github.io/graphql/#sec-Operation-Name-Uniqueness
+  = DuplicateOperation AST.Name
+  -- | 'MultipleAnonymousOperation' means there was more than one anonymous
+  -- operation defined.
+  --
+  -- https://facebook.github.io/graphql/#sec-Lone-Anonymous-Operation
+  | MultipleAnonymousOperation Int
   deriving (Eq, Show)
 
-
+-- | Identify all of the validation errors in @doc@.
+--
+-- An empty list means no errors.
+--
+-- https://facebook.github.io/graphql/#sec-Validation
 getErrors :: AST.QueryDocument -> [ValidationError]
-getErrors doc = duplicateOperations
+getErrors doc = duplicateOperations <> multipleAnonymousOps
   where
-    duplicateOperations = DuplicateOperation <$> findDuplicates nodeNames
-    nodeNames = [ AST.getNodeName . AST.getNode $ op | AST.DefinitionOperation op <- AST.getDefinitions doc ]
+    duplicateOperations = map DuplicateOperation (findDuplicates (catMaybes nodeNames))
+    multipleAnonymousOps =
+      case length (filter (== Nothing) nodeNames) of
+        0 -> mempty
+        1 -> mempty
+        n -> [MultipleAnonymousOperation n]
+    nodeNames = [ getOperationName op | AST.DefinitionOperation op <- AST.getDefinitions doc ]
 
+-- | 'getOperationName' returns the name of the operatioen if there is any,
+-- 'Nothing' otherwise.
+getOperationName :: AST.OperationDefinition -> Maybe AST.Name
+getOperationName (AST.Query (AST.Node name _ _ _)) = pure name
+getOperationName (AST.Mutation (AST.Node name _ _ _)) = pure name
+getOperationName (AST.AnonymousQuery _) = empty
 
 -- | Return a list of all the elements with duplicates. The list of duplicates
 -- itself will not contain duplicates.

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -58,9 +58,9 @@ type QueryRoot {
 }
 -}
 
-newtype ValidDocument = Valid AST.Document deriving (Eq, Show)
+newtype ValidDocument = Valid AST.QueryDocument deriving (Eq, Show)
 
-validate :: Alternative m => AST.Document -> m ValidDocument
+validate :: Alternative m => AST.QueryDocument -> m ValidDocument
 validate = pure . Valid
 
 data ValidationError
@@ -68,7 +68,7 @@ data ValidationError
   deriving (Eq, Show)
 
 
-getErrors :: AST.Document -> [ValidationError]
+getErrors :: AST.QueryDocument -> [ValidationError]
 getErrors doc = duplicateOperations
   where
     duplicateOperations = DuplicateOperation <$> findDuplicates nodeNames

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -35,7 +35,7 @@ tests :: IO TestTree
 tests = testSpec "AST" $ do
   describe "Parser and encoder" $ do
     it "roundtrips on minified documents" $ do
-      let actual = Encoder.document <$> parseOnly Parser.document kitchenSink
+      let actual = Encoder.queryDocument <$> parseOnly Parser.queryDocument kitchenSink
       actual `shouldBe` Right kitchenSink
     describe "parsing numbers" $ do
       it "works for some integers" $ do
@@ -88,8 +88,8 @@ tests = testSpec "AST" $ do
                          name
                        }
                      }|]
-      let Right parsed = parseOnly Parser.document query
-      let expected = AST.Document
+      let Right parsed = parseOnly Parser.queryDocument query
+      let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                        (AST.Query
                          (AST.Node Nothing [] []
@@ -115,8 +115,8 @@ tests = testSpec "AST" $ do
                          }
                        }
                      }|]
-      let Right parsed = parseOnly Parser.document query
-      let expected = AST.Document
+      let Right parsed = parseOnly Parser.queryDocument query
+      let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                          (AST.Query
                            (AST.Node Nothing [] []
@@ -136,8 +136,8 @@ tests = testSpec "AST" $ do
                       }
                     }
                     |]
-      let Right parsed = parseOnly Parser.document query
-      let expected = AST.Document
+      let Right parsed = parseOnly Parser.queryDocument query
+      let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                          (AST.Query
                            (AST.Node (Just (AST.unsafeMakeName "houseTrainedQuery"))

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -91,17 +91,16 @@ tests = testSpec "AST" $ do
       let Right parsed = parseOnly Parser.queryDocument query
       let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
-                       (AST.Query
-                         (AST.Node Nothing [] []
-                           [ AST.SelectionField
-                               (AST.Field Nothing dog [] []
-                                 [ AST.SelectionField (AST.Field Nothing someName [] [] [])
-                                 ])
-                           ]))
+                       (AST.AnonymousQuery
+                         [ AST.SelectionField
+                           (AST.Field Nothing dog [] []
+                             [ AST.SelectionField (AST.Field Nothing someName [] [] [])
+                             ])
+                         ])
                      ]
       parsed `shouldBe` expected
 
-    it "silently mis-parses invalid documents" $ do
+    it "parses invalid documents" $ do
       let query = [r|{
                        dog {
                          name
@@ -118,13 +117,23 @@ tests = testSpec "AST" $ do
       let Right parsed = parseOnly Parser.queryDocument query
       let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
-                         (AST.Query
-                           (AST.Node Nothing [] []
+                       (AST.AnonymousQuery
+                         [ AST.SelectionField
+                           (AST.Field Nothing dog [] []
+                             [ AST.SelectionField (AST.Field Nothing someName [] [] [])
+                             ])
+                         ])
+                     , AST.DefinitionOperation
+                       (AST.Query
+                        (AST.Node (AST.unsafeMakeName "getName") [] []
+                         [ AST.SelectionField
+                           (AST.Field Nothing dog [] []
                             [ AST.SelectionField
-                                (AST.Field Nothing dog [] []
-                                  [ AST.SelectionField (AST.Field Nothing someName [] [] [])
-                                  ])
-                            ]))
+                              (AST.Field Nothing (AST.unsafeMakeName "owner") [] []
+                               [ AST.SelectionField (AST.Field Nothing someName [] [] [])
+                               ])
+                            ])
+                         ]))
                      ]
       parsed `shouldBe` expected
 
@@ -140,7 +149,7 @@ tests = testSpec "AST" $ do
       let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                          (AST.Query
-                           (AST.Node (Just (AST.unsafeMakeName "houseTrainedQuery"))
+                           (AST.Node (AST.unsafeMakeName "houseTrainedQuery")
                             [ AST.VariableDefinition
                                 (AST.Variable (AST.unsafeMakeName "atOtherHomes"))
                                 (AST.TypeNamed (AST.NamedType (AST.unsafeMakeName "Boolean")))

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -4,7 +4,7 @@ module Examples.UnionExample  where
 import Protolude hiding (Enum)
 import qualified GraphQL.Internal.AST as AST
 import Data.Attoparsec.Text (parseOnly, endOfInput)
-import GraphQL.Internal.Parser (document)
+import GraphQL.Internal.Parser (queryDocument)
 
 import GraphQL.API
 import GraphQL.Server
@@ -29,6 +29,6 @@ exampleQuery = buildResolver @IO @T tHandler (query "{ ... on O1 { o1 } ... on O
 
 query :: Text -> AST.SelectionSet
 query q =
-  let Right (AST.Document [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
-       parseOnly (document <* endOfInput) q
+  let Right (AST.QueryDocument [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
+       parseOnly (queryDocument <* endOfInput) q
   in selectionSet

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -22,7 +22,7 @@ import qualified GraphQL.Internal.AST as AST
 import GraphQL.Value (Value)
 import Data.Aeson (encode)
 
-import GraphQL.Internal.Parser (document)
+import GraphQL.Internal.Parser (queryDocument)
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 
 -- Test a custom error monad
@@ -39,8 +39,8 @@ tHandler =
 
 getQuery :: Text -> AST.SelectionSet
 getQuery query =
-  let Right (AST.Document [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
-        parseOnly (document <* endOfInput) query
+  let Right (AST.QueryDocument [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
+        parseOnly (queryDocument <* endOfInput) query
   in selectionSet
 
 runQuery :: AST.SelectionSet -> IO (Either Text Value)

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -39,7 +39,7 @@ tHandler =
 
 getQuery :: Text -> AST.SelectionSet
 getQuery query =
-  let Right (AST.QueryDocument [AST.DefinitionOperation (AST.Query (AST.Node _ _ _ selectionSet))]) =
+  let Right (AST.QueryDocument [AST.DefinitionOperation (AST.AnonymousQuery selectionSet)]) =
         parseOnly (queryDocument <* endOfInput) query
   in selectionSet
 

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -30,7 +30,7 @@ tests = testSpec "Validation" $ do
       let doc = AST.QueryDocument
                 [ AST.DefinitionOperation
                   ( AST.Query
-                    ( AST.Node (Just me) [] []
+                    ( AST.Node me [] []
                       [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                       ]
                     )
@@ -42,20 +42,35 @@ tests = testSpec "Validation" $ do
       let doc = AST.QueryDocument
                 [ AST.DefinitionOperation
                   ( AST.Query
-                    ( AST.Node (Just me) [] []
+                    ( AST.Node me [] []
                       [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                       ]
                     )
                   )
                 , AST.DefinitionOperation
                   ( AST.Query
-                    ( AST.Node (Just me) [] []
+                    ( AST.Node me [] []
                       [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                       ]
                     )
                   )
                 ]
-      getErrors doc `shouldBe` [DuplicateOperation (Just me)]
+      getErrors doc `shouldBe` [DuplicateOperation me]
+
+    it "Detects duplicate anonymous operations" $ do
+      let doc = AST.QueryDocument
+                [ AST.DefinitionOperation
+                  ( AST.AnonymousQuery
+                    [ AST.SelectionField (AST.Field Nothing someName [] [] [])
+                    ]
+                  )
+                , AST.DefinitionOperation
+                  ( AST.AnonymousQuery
+                    [ AST.SelectionField (AST.Field Nothing someName [] [] [])
+                    ]
+                  )
+                ]
+      getErrors doc `shouldBe` [MultipleAnonymousOperation 2]
 
   describe "findDuplicates" $ do
     prop "returns empty on unique lists" $ do

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -27,7 +27,7 @@ tests :: IO TestTree
 tests = testSpec "Validation" $ do
   describe "getErrors" $ do
     it "Treats simple queries as valid" $ do
-      let doc = AST.Document
+      let doc = AST.QueryDocument
                 [ AST.DefinitionOperation
                   ( AST.Query
                     ( AST.Node (Just me) [] []
@@ -39,7 +39,7 @@ tests = testSpec "Validation" $ do
       getErrors doc `shouldBe` []
 
     it "Detects duplicate operation names" $ do
-      let doc = AST.Document
+      let doc = AST.QueryDocument
                 [ AST.DefinitionOperation
                   ( AST.Query
                     ( AST.Node (Just me) [] []


### PR DESCRIPTION
In #42, @teh was surprised about the behaviour of node names. This is partly due to the structure of the AST, which previous just said that an anonymous query was a query with an empty name. 

This PR gives anonymous queries a distinct branch in the AST, updates the validation logic to be a bit more explicit, and fixes the parser while it's at it (it more or less falls out from having correct types). 

Also changes the top level "document" concept, splitting it into query document and schema document. The reasoning here is that you just can't send type definitions in a query, so don't bother trying to parse them while parsing queries. The upshot is that it further simplifies validation. 