### PR TITLE
Parse null

### DIFF
--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -195,7 +195,8 @@ data Value = ValueVariable Variable
            | ValueEnum Name
            | ValueList ListValue
            | ValueObject ObjectValue
-             deriving (Eq,Show)
+           | ValueNull
+           deriving (Eq, Show)
 
 instance Arbitrary Value where
   arbitrary = oneof [ ValueVariable <$> arbitrary
@@ -206,6 +207,7 @@ instance Arbitrary Value where
                     , ValueEnum <$> arbitrary
                     , ValueList <$> arbitrary
                     , ValueObject <$> arbitrary
+                    , pure ValueNull
                     ]
 
 newtype StringValue = StringValue Text deriving (Eq,Show)

--- a/src/GraphQL/Internal/Encoder.hs
+++ b/src/GraphQL/Internal/Encoder.hs
@@ -101,6 +101,7 @@ value (AST.ValueString   x) = stringValue x
 value (AST.ValueEnum     x) = AST.getNameText x
 value (AST.ValueList     x) = listValue x
 value (AST.ValueObject   x) = objectValue x
+value AST.ValueNull = "null"
 
 booleanValue :: Bool -> Text
 booleanValue True  = "true"

--- a/src/GraphQL/Internal/Parser.hs
+++ b/src/GraphQL/Internal/Parser.hs
@@ -136,6 +136,7 @@ typeCondition = namedType
 value :: Parser AST.Value
 value = tok (AST.ValueVariable <$> (variable <?> "variable")
   <|> (number <?> "number")
+  <|> AST.ValueNull     <$  tok "null"
   <|> AST.ValueBoolean  <$> (booleanValue <?> "booleanValue")
   <|> AST.ValueString   <$> (stringValue <?> "stringValue")
   -- `true` and `false` have been tried before

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -20,11 +20,6 @@ import qualified GraphQL.Internal.Encoder as Encoder
 kitchenSink :: Text
 kitchenSink = "query queryName($foo:ComplexType,$site:Site=MOBILE){whoever123is:node(id:[123,456]){id,... on User@defer{field2{id,alias:field1(first:10,after:$foo)@include(if:$foo){id,...frag}}}}}mutation likeStory{like(story:123)@defer{story{id}}}fragment frag on Friend{foo(size:$size,bar:$b,obj:{key:\"value\"})}\n"
 
-genASTValue :: Gen AST.Value
-genASTValue = do
-  v <- valueToAST <$> arbitrary
-  maybe discard pure v
-
 dog :: AST.Name
 dog = AST.unsafeMakeName "dog"
 
@@ -62,7 +57,7 @@ tests = testSpec "AST" $ do
         parseOnly Parser.value output `shouldBe` Right input
     describe "parsing values" $ do
       prop "works for all literal values" $ do
-        forAll genASTValue $ \x -> parseOnly Parser.value (Encoder.value x) `shouldBe` Right x
+        \x -> parseOnly Parser.value (Encoder.value x) `shouldBe` Right x
       it "parses ununusual objects" $ do
         let input = AST.ValueObject
                     (AST.ObjectValue

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -8,11 +8,11 @@ import Protolude
 import Data.Attoparsec.Text (parseOnly)
 import Text.RawString.QQ (r)
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (Gen, arbitrary, discard, forAll)
+import Test.QuickCheck (Gen, arbitrary, discard, forAll, resize)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
-import GraphQL.Value (String(..), valueToAST)
+import GraphQL.Value (String(..))
 import qualified GraphQL.Internal.AST as AST
 import qualified GraphQL.Internal.Parser as Parser
 import qualified GraphQL.Internal.Encoder as Encoder
@@ -57,7 +57,7 @@ tests = testSpec "AST" $ do
         parseOnly Parser.value output `shouldBe` Right input
     describe "parsing values" $ do
       prop "works for all literal values" $ do
-        \x -> parseOnly Parser.value (Encoder.value x) `shouldBe` Right x
+        forAll (resize 3 arbitrary) $ \x -> parseOnly Parser.value (Encoder.value x) `shouldBe` Right x
       it "parses ununusual objects" $ do
         let input = AST.ValueObject
                     (AST.ObjectValue

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -3,7 +3,7 @@ module ValueTests (tests) where
 import Protolude
 
 import Test.Hspec.QuickCheck (prop)
-import Test.QuickCheck (forAll)
+import Test.QuickCheck (arbitrary, forAll, resize)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
 
@@ -59,7 +59,7 @@ tests = testSpec "Value" $ do
     prop "Non-empty lists" $ forAll (arbitraryNonEmpty @Int32) prop_roundtripValue
   describe "AST" $ do
     prop "Values can be converted to AST and back" $ do
-      prop_roundtripFromValue
+      forAll (resize 5 arbitrary) prop_roundtripFromValue
     prop "Values can be converted from AST and back" $ do
       prop_roundtripFromAST
     it "Objects converted from AST have unique fields" $ do


### PR DESCRIPTION
Turns out the AST wouldn't parse 'null'. Who knew?

Also had to make some changes to generators to make them run fast.