### PR TITLE
Generic enum

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.14.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -23,7 +23,7 @@ library
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
-  ghc-options: -Wall -fno-warn-redundant-constraints -Werror
+  ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
       base >= 4.9 && < 5
     , protolude
@@ -38,6 +38,7 @@ library
   exposed-modules:
       GraphQL
       GraphQL.API
+      GraphQL.API.Enum
       GraphQL.Internal.Arbitrary
       GraphQL.Internal.AST
       GraphQL.Internal.Encoder

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -23,7 +23,7 @@ library
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
-  ghc-options: -Wall -fno-warn-redundant-constraints
+  ghc-options: -Wall -fno-warn-redundant-constraints -Werror
   build-depends:
       base >= 4.9 && < 5
     , protolude

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -231,7 +231,7 @@ instance forall t. (HasAnnotatedType t) => HasAnnotatedType (List t) where
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedType (Enum ks enum) where
   getAnnotatedType = do
     let name = nameFromSymbol @ks
-    let enums = sequenceA (enumValues @enum Proxy) :: Either NameError [Name]
+    let enums = sequenceA (enumValues @enum) :: Either NameError [Name]
     let et = EnumTypeDefinition <$> name <*> map (map EnumValueDefinition) enums
     TypeNonNull . NonNullTypeNamed . DefinedType . TypeDefinitionEnum <$> et
 
@@ -282,6 +282,6 @@ instance forall t. (HasAnnotatedInputType t) => HasAnnotatedInputType (List t) w
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedInputType (Enum ks enum) where
   getAnnotatedInputType = do
     let name = nameFromSymbol @ks
-        enums = sequenceA (enumValues @enum Proxy) :: Either NameError [Name]
+        enums = sequenceA (enumValues @enum) :: Either NameError [Name]
     let et = EnumTypeDefinition <$> name <*> map (map EnumValueDefinition) enums
     TypeNonNull . NonNullTypeNamed . DefinedInputType . InputTypeDefinitionEnum <$> et

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeInType #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Type-level definitions for a GraphQL schema.
 module GraphQL.API
@@ -231,7 +231,7 @@ instance forall t. (HasAnnotatedType t) => HasAnnotatedType (List t) where
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedType (Enum ks enum) where
   getAnnotatedType = do
     let name = nameFromSymbol @ks
-    let enums = sequenceA (enumValues @enum) :: Either NameError [Name]
+    let enums = sequenceA (enumValues @enum Proxy) :: Either NameError [Name]
     let et = EnumTypeDefinition <$> name <*> map (map EnumValueDefinition) enums
     TypeNonNull . NonNullTypeNamed . DefinedType . TypeDefinitionEnum <$> et
 
@@ -282,6 +282,6 @@ instance forall t. (HasAnnotatedInputType t) => HasAnnotatedInputType (List t) w
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedInputType (Enum ks enum) where
   getAnnotatedInputType = do
     let name = nameFromSymbol @ks
-        enums = sequenceA (enumValues @enum) :: Either NameError [Name]
+        enums = sequenceA (enumValues @enum Proxy) :: Either NameError [Name]
     let et = EnumTypeDefinition <$> name <*> map (map EnumValueDefinition) enums
     TypeNonNull . NonNullTypeNamed . DefinedInputType . InputTypeDefinitionEnum <$> et

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -231,7 +231,8 @@ instance forall t. (HasAnnotatedType t) => HasAnnotatedType (List t) where
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedType (Enum ks enum) where
   getAnnotatedType = do
     let name = nameFromSymbol @ks
-    let et = EnumTypeDefinition <$> name <*> pure (map EnumValueDefinition (enumValues @enum Proxy))
+    let enums = sequenceA (enumValues @enum Proxy) :: Either NameError [Name]
+    let et = EnumTypeDefinition <$> name <*> map (map EnumValueDefinition) enums
     TypeNonNull . NonNullTypeNamed . DefinedType . TypeDefinitionEnum <$> et
 
 instance forall ks as. (KnownSymbol ks, UnionTypeObjectTypeDefinitionList as) => HasAnnotatedType (Union ks as) where
@@ -281,5 +282,6 @@ instance forall t. (HasAnnotatedInputType t) => HasAnnotatedInputType (List t) w
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedInputType (Enum ks enum) where
   getAnnotatedInputType = do
     let name = nameFromSymbol @ks
-    let et = EnumTypeDefinition <$> name <*> pure (map EnumValueDefinition (enumValues @enum Proxy))
+        enums = sequenceA (enumValues @enum Proxy) :: Either NameError [Name]
+    let et = EnumTypeDefinition <$> name <*> map (map EnumValueDefinition) enums
     TypeNonNull . NonNullTypeNamed . DefinedInputType . InputTypeDefinitionEnum <$> et

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Type-level definitions for a GraphQL schema.
 module GraphQL.API
@@ -230,7 +231,7 @@ instance forall t. (HasAnnotatedType t) => HasAnnotatedType (List t) where
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedType (Enum ks enum) where
   getAnnotatedType = do
     let name = nameFromSymbol @ks
-    let et = EnumTypeDefinition <$> name <*> pure (map EnumValueDefinition (enumValues @enum))
+    let et = EnumTypeDefinition <$> name <*> pure (map EnumValueDefinition (enumValues @enum Proxy))
     TypeNonNull . NonNullTypeNamed . DefinedType . TypeDefinitionEnum <$> et
 
 instance forall ks as. (KnownSymbol ks, UnionTypeObjectTypeDefinitionList as) => HasAnnotatedType (Union ks as) where
@@ -280,5 +281,5 @@ instance forall t. (HasAnnotatedInputType t) => HasAnnotatedInputType (List t) w
 instance forall ks enum. (KnownSymbol ks, GraphQLEnum enum) => HasAnnotatedInputType (Enum ks enum) where
   getAnnotatedInputType = do
     let name = nameFromSymbol @ks
-    let et = EnumTypeDefinition <$> name <*> pure (map EnumValueDefinition (enumValues @enum))
+    let et = EnumTypeDefinition <$> name <*> pure (map EnumValueDefinition (enumValues @enum Proxy))
     TypeNonNull . NonNullTypeNamed . DefinedInputType . InputTypeDefinitionEnum <$> et

--- a/src/GraphQL/API/Enum.hs
+++ b/src/GraphQL/API/Enum.hs
@@ -88,12 +88,9 @@ instance forall conName p b sa sb f.
 -- | For each enum type we need 1) a list of all possible values 2) a
 -- way to serialise and 3) deserialise.
 class GraphQLEnum a where
-  -- Sadly we can't use visible type application to make @enumValues@
-  -- a nullary function because the solver can't constrain the
-  -- function signature without an @a@ argument. Hence the Proxy.
-  enumValues :: Proxy a -> [Either NameError Name]
-  default enumValues :: (Generic a, GenricEnumValues (Rep a)) => Proxy a -> [Either NameError Name]
-  enumValues _ = genericEnumValues @(Rep a)
+  enumValues :: [Either NameError Name]
+  default enumValues :: (Generic a, GenricEnumValues (Rep a)) => [Either NameError Name]
+  enumValues = genericEnumValues @(Rep a)
 
   enumFromValue :: GValue.Value -> Either Text a
   default enumFromValue :: (Generic a, GenricEnumValues (Rep a)) => GValue.Value -> Either Text a

--- a/src/GraphQL/API/Enum.hs
+++ b/src/GraphQL/API/Enum.hs
@@ -20,69 +20,69 @@ import GHC.Generics (M1(..), Rep, Meta(..), C1, U1(..), D, (:+:)(..))
 import GHC.TypeLits (KnownSymbol, TypeError, ErrorMessage(..))
 
 
-class GenricEnumValues (r :: Type -> Type) where
+class GenricEnumValues (f :: Type -> Type) where
   genericEnumValues :: [Name]
-  genericEnumFromValue :: GValue.Value -> Either Text (r p)
-  genericEnumToValue :: r p -> GValue.Value
+  genericEnumFromValue :: GValue.Value -> Either Text (f p)
+  genericEnumToValue :: f p -> GValue.Value
 
-instance forall n m p f nt.
-  ( KnownSymbol n
+instance forall conName m p f nt.
+  ( KnownSymbol conName
   , KnownSymbol m
   , KnownSymbol p
   , GenricEnumValues f
-  ) => GenricEnumValues (M1 D ('MetaData n m p nt) f) where
+  ) => GenricEnumValues (M1 D ('MetaData conName m p nt) f) where
   genericEnumValues = genericEnumValues @f
   genericEnumFromValue v@(GValue.ValueEnum _) = M1 <$> genericEnumFromValue v
   genericEnumFromValue x = Left ("Not an enum: " <> show x)
   genericEnumToValue (M1 gv) = genericEnumToValue gv
 
-instance forall n f p b.
-  ( KnownSymbol n
+instance forall conName f p b.
+  ( KnownSymbol conName
   , GenricEnumValues f
-  ) => GenricEnumValues (C1 ('MetaCons n p b) U1 :+: f) where
-  genericEnumValues = let Right name = nameFromSymbol @n in name:(genericEnumValues @f)
+  ) => GenricEnumValues (C1 ('MetaCons conName p b) U1 :+: f) where
+  genericEnumValues = let Right name = nameFromSymbol @conName in name:(genericEnumValues @f)
   genericEnumFromValue v@(GValue.ValueEnum vname) =
-    case nameFromSymbol @n of
+    case nameFromSymbol @conName of
       Right name -> if name == vname
                     then L1 <$> Right (M1 U1)
                     else R1 <$> genericEnumFromValue v
       Left x -> Left ("Not a valid enum name: " <> show x)
   genericEnumFromValue _ = panic "This case should have been caught at top-level. Please file a bug."
   genericEnumToValue (L1 _) =
-    let Right name = nameFromSymbol @n
+    let Right name = nameFromSymbol @conName
     in GValue.ValueEnum name
   genericEnumToValue (R1 gv) = genericEnumToValue gv
 
-instance forall n p b. (KnownSymbol n) => GenricEnumValues (C1 ('MetaCons n p b) U1) where
-  genericEnumValues = let Right name = nameFromSymbol @n in [name]
+instance forall conName p b. (KnownSymbol conName) => GenricEnumValues (C1 ('MetaCons conName p b) U1) where
+  genericEnumValues = let Right name = nameFromSymbol @conName in [name]
   genericEnumFromValue (GValue.ValueEnum vname) =
-    case nameFromSymbol @n of
+    case nameFromSymbol @conName of
       Right name -> if name == vname
                     then Right (M1 U1)
                     else Left ("Not a valid enum name: " <> show vname)
       Left x -> Left ("Not a valid enum name: " <> show x)
   genericEnumFromValue _ = panic "This case should have been caught at top-level. Please file a bug."
   genericEnumToValue (M1 _) =
-    let Right name = nameFromSymbol @n
+    let Right name = nameFromSymbol @conName
     in GValue.ValueEnum name
 
 -- TODO(tom): better type errors using `n`. Also type errors for other
 -- invalid constructors.
-instance forall n p b sa sb.
-  ( TypeError ('Text "Constructor not unary: " ':<>: 'Text n)
-  , KnownSymbol n
-  ) => GenricEnumValues (C1 ('MetaCons n p b) (S1 sa sb)) where
-  genericEnumValues = undefined
-  genericEnumFromValue = undefined
-  genericEnumToValue = undefined
+instance forall conName p b sa sb.
+  ( TypeError ('Text "Constructor not unary: " ':<>: 'Text conName)
+  , KnownSymbol conName
+  ) => GenricEnumValues (C1 ('MetaCons conName p b) (S1 sa sb)) where
+  genericEnumValues = notImplemented
+  genericEnumFromValue = notImplemented
+  genericEnumToValue = notImplemented
 
-instance forall n p b sa sb f.
-  ( TypeError ('Text "Constructor not unary: " ':<>: 'Text n)
-  , KnownSymbol n
-  ) => GenricEnumValues (C1 ('MetaCons n p b) (S1 sa sb) :+: f) where
-  genericEnumValues = undefined
-  genericEnumFromValue = undefined
-  genericEnumToValue = undefined
+instance forall conName p b sa sb f.
+  ( TypeError ('Text "Constructor not unary: " ':<>: 'Text conName)
+  , KnownSymbol conName
+  ) => GenricEnumValues (C1 ('MetaCons conName p b) (S1 sa sb) :+: f) where
+  genericEnumValues = notImplemented
+  genericEnumFromValue = notImplemented
+  genericEnumToValue = notImplemented
 
 
 -- | For each enum type we need 1) a list of all possible values 2) a

--- a/src/GraphQL/API/Enum.hs
+++ b/src/GraphQL/API/Enum.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module GraphQL.API.Enum where
+
+import Protolude hiding (Enum, U1, TypeError)
+import GraphQL.Internal.AST (Name, nameFromSymbol)
+import qualified GraphQL.Value as GValue
+import GHC.Generics -- TODO explicit imports
+import GHC.TypeLits (KnownSymbol, TypeError, ErrorMessage(..))
+
+{-
+For values we need to extract the whole representation, e.g.:
+
+λ  :kind! (Rep B)
+(Rep B) :: * -> *
+= D1
+    ('MetaData "B" "Ghci1" "interactive" 'False)
+    (C1 ('MetaCons "B1" 'PrefixI 'False) U1
+     :+: (C1 ('MetaCons "B2" 'PrefixI 'False) U1
+          :+: C1 ('MetaCons "B3" 'PrefixI 'False) U1))
+-}
+
+class GenricEnumValues (r :: Type -> Type) where
+  genericEnumValues :: [Name]
+  genericEnumFromValue :: GValue.Value -> Either Text (r p)
+
+instance forall n m p f nt. (KnownSymbol n, KnownSymbol m, KnownSymbol p, GenricEnumValues f) => GenricEnumValues (M1 D ('MetaData n m p nt) f) where
+  genericEnumValues = genericEnumValues @f
+  genericEnumFromValue v@(GValue.ValueEnum _) = fmap M1 (genericEnumFromValue v)
+  genericEnumFromValue x = Left ("Not an enum: " <> show x)
+
+instance (KnownSymbol n, GenricEnumValues f) => GenricEnumValues (C1 ('MetaCons n p b) U1 :+: f) where
+  genericEnumValues = let Right name = nameFromSymbol @n in name:(genericEnumValues @f)
+  genericEnumFromValue v@(GValue.ValueEnum vname) =
+    case nameFromSymbol @n of
+      Right name -> if name == vname
+                    then fmap L1 (Right (M1 U1 :: (C1 ('MetaCons n p b) U1 f')))
+                    else fmap R1 (genericEnumFromValue v)
+      Left x -> Left ("Not a valid enum name: " <> show x)
+  genericEnumFromValue _ = panic "This case should have been caught at top-level. Please file a bug."
+
+instance forall n p b. (KnownSymbol n) => GenricEnumValues (C1 ('MetaCons n p b) U1) where
+  genericEnumValues = let Right name = nameFromSymbol @n in [name]
+  genericEnumFromValue (GValue.ValueEnum vname) =
+    case nameFromSymbol @n of
+      Right name -> if name == vname
+                    then Right (M1 U1 :: (C1 ('MetaCons n p b) U1 f'))
+                    else Left ("Not a valid enum name: " <> show vname)
+      Left x -> Left ("Not a valid enum name: " <> show x)
+  genericEnumFromValue _ = panic "This case should have been caught at top-level. Please file a bug."
+
+
+-- TODO(tom): better type errors using `n`
+instance ( TypeError ('Text "Constructor not unary: " ':<>: 'Text n), KnownSymbol n
+         ) => GenricEnumValues (C1 ('MetaCons n p b) (S1 sa sb)) where
+  genericEnumValues = undefined
+  genericEnumFromValue = undefined
+
+instance ( TypeError ('Text "Constructor not unary: " ':<>: 'Text n), KnownSymbol n
+         ) => GenricEnumValues (C1 ('MetaCons n p b) (S1 sa sb) :+: f) where
+  genericEnumValues = undefined
+  genericEnumFromValue = undefined
+
+-- | For each enum type we need 1) a list of all possible values 2) a
+-- way to serialise and 3) deserialise.
+class (GenricEnumValues (Rep a), Generic a) => GraphQLEnum a where
+  enumValues :: [Name]
+  enumValues = genericEnumValues @(Rep a)
+
+  enumFromValue :: GValue.Value -> Either Text a
+  enumFromValue v = fmap to (genericEnumFromValue v)
+  enumToValue :: a -> GValue.Value
+
+  enumToValue _ = undefined -- TODO
+
+instance GraphQLEnum B
+
+data B = B1 | B2 | B3 deriving (Generic, Show)
+data A = A1 | A2 Text | A3 deriving (Generic, Show)

--- a/src/GraphQL/API/Enum.hs
+++ b/src/GraphQL/API/Enum.hs
@@ -32,7 +32,7 @@ instance forall n m p f nt.
   , GenricEnumValues f
   ) => GenricEnumValues (M1 D ('MetaData n m p nt) f) where
   genericEnumValues = genericEnumValues @f
-  genericEnumFromValue v@(GValue.ValueEnum _) = fmap M1 (genericEnumFromValue v)
+  genericEnumFromValue v@(GValue.ValueEnum _) = M1 <$> genericEnumFromValue v
   genericEnumFromValue x = Left ("Not an enum: " <> show x)
   genericEnumToValue (M1 gv) = genericEnumToValue gv
 
@@ -44,8 +44,8 @@ instance forall n f p b.
   genericEnumFromValue v@(GValue.ValueEnum vname) =
     case nameFromSymbol @n of
       Right name -> if name == vname
-                    then fmap L1 (Right (M1 U1 :: (C1 ('MetaCons n p b) U1 f')))
-                    else fmap R1 (genericEnumFromValue v)
+                    then L1 <$> Right (M1 U1)
+                    else R1 <$> genericEnumFromValue v
       Left x -> Left ("Not a valid enum name: " <> show x)
   genericEnumFromValue _ = panic "This case should have been caught at top-level. Please file a bug."
   genericEnumToValue (L1 _) =
@@ -58,7 +58,7 @@ instance forall n p b. (KnownSymbol n) => GenricEnumValues (C1 ('MetaCons n p b)
   genericEnumFromValue (GValue.ValueEnum vname) =
     case nameFromSymbol @n of
       Right name -> if name == vname
-                    then Right (M1 U1 :: (C1 ('MetaCons n p b) U1 f'))
+                    then Right (M1 U1)
                     else Left ("Not a valid enum name: " <> show vname)
       Left x -> Left ("Not a valid enum name: " <> show x)
   genericEnumFromValue _ = panic "This case should have been caught at top-level. Please file a bug."
@@ -97,7 +97,7 @@ class GraphQLEnum a where
 
   enumFromValue :: GValue.Value -> Either Text a
   default enumFromValue :: (Generic a, GenricEnumValues (Rep a)) => GValue.Value -> Either Text a
-  enumFromValue v = fmap to (genericEnumFromValue v)
+  enumFromValue v = to <$> genericEnumFromValue v
 
   enumToValue :: a -> GValue.Value
   default enumToValue :: (Generic a, GenricEnumValues (Rep a)) => a -> GValue.Value

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -1,11 +1,16 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
 module GraphQL.Internal.AST
   ( Name(getNameText)
   , NameError
   , formatNameError
   , nameParser
   , makeName
+  , nameFromSymbol
   , unsafeMakeName
   , QueryDocument(..)
   , SchemaDocument(..)
@@ -52,6 +57,7 @@ module GraphQL.Internal.AST
 
 import Protolude hiding (Type)
 
+import GHC.TypeLits (Symbol, KnownSymbol, symbolVal)
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.Text as A
 import Data.Char (isDigit)
@@ -146,6 +152,10 @@ data Node = Node Name [VariableDefinition] [Directive] SelectionSet
 -- TODO: Just make Node implement HasName.
 getNodeName :: Node -> Name
 getNodeName (Node name _ _ _) = name
+
+-- | Convert a type-level 'Symbol' into a GraphQL 'Name'.
+nameFromSymbol :: forall (n :: Symbol). KnownSymbol n => Either NameError Name
+nameFromSymbol = makeName (toS (symbolVal @n Proxy))
 
 data VariableDefinition = VariableDefinition Variable Type (Maybe DefaultValue)
                           deriving (Eq,Show)

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -186,7 +186,7 @@ instance forall m hg. (Applicative m, HasGraph m hg) => HasGraph m (API.List hg)
 
 instance forall m ks enum. (Applicative m, API.GraphQLEnum enum) => HasGraph m (API.Enum ks enum) where
   type Handler m (API.Enum ks enum) = enum
-  buildResolver handler _ = (pure . ok . API.enumToValue) handler
+  buildResolver handler _ = (pure . ok . GValue.ValueEnum . API.enumToValue) handler
 
 
 -- TODO: lookup is O(N log N) in number of arguments (we linearly search each

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -46,7 +46,7 @@ import GraphQL.Value (Value(..))
 data DogCommandEnum = Sit | Down | Heel
 
 instance GraphQLEnum DogCommandEnum where
-  enumValues = map unsafeMakeName ["SIT", "DOWN", "HEEL"]
+  enumValues _ = map unsafeMakeName ["SIT", "DOWN", "HEEL"]
   enumToValue _ = undefined
   enumFromValue (ValueEnum x) =
     case getNameText x of
@@ -78,7 +78,7 @@ type Human = Object "Human" '[Sentient] '[Field "name" Text]
 data CatCommandEnum = Jump
 
 instance GraphQLEnum CatCommandEnum where
-  enumValues = [unsafeMakeName "JUMP"]
+  enumValues _ = [unsafeMakeName "JUMP"]
   enumToValue = undefined
   enumFromValue (ValueEnum x)
     | getNameText x == "JUMP" = pure Jump

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE DataKinds, TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DeriveGeneric #-}
 module TypeTests (tests) where
 
 import Protolude hiding (Down, Enum)
@@ -22,7 +24,7 @@ import GraphQL.API
   , getFieldDefinition
   , getInterfaceDefinition
   )
-import GraphQL.Internal.AST (getNameText, unsafeMakeName, makeName)
+import GraphQL.Internal.AST (unsafeMakeName)
 import GraphQL.Internal.Schema
   ( EnumTypeDefinition(..)
   , EnumValueDefinition(..)
@@ -39,23 +41,12 @@ import GraphQL.Internal.Schema
   , Builtin(..)
   , InputType(..)
   )
-import GraphQL.Value (Value(..))
 
 -- Examples taken from the spec
 
-data DogCommandEnum = Sit | Down | Heel
+data DogCommandEnum = Sit | Down | Heel deriving (Show, Generic)
 
-instance GraphQLEnum DogCommandEnum where
-  enumValues = map makeName ["SIT", "DOWN", "HEEL"]
-  enumToValue _ = undefined
-  enumFromValue (ValueEnum x) =
-    case getNameText x of
-      "SIT" -> pure Sit
-      "DOWN" -> pure Down
-      "HEEL" -> pure Heel
-      _ -> throwError ("Unrecognized enum: " <> show x)
-  enumFromValue x = throwError ("Not an enum: " <> show x)
-
+instance GraphQLEnum DogCommandEnum
 
 -- Alternative might be a sum type with deriving Generic and 0-arity constructors?
 type DogCommand = Enum "DogCommand" DogCommandEnum
@@ -75,15 +66,9 @@ type Pet = Interface "Pet" '[Field "name" Text]
 
 type Human = Object "Human" '[Sentient] '[Field "name" Text]
 
-data CatCommandEnum = Jump
+data CatCommandEnum = Jump deriving Generic
 
-instance GraphQLEnum CatCommandEnum where
-  enumValues = [makeName "JUMP"]
-  enumToValue = undefined
-  enumFromValue (ValueEnum x)
-    | getNameText x == "JUMP" = pure Jump
-    | otherwise = throwError ("Unrecognized enum: " <> show x)
-  enumFromValue x = throwError ("Not an enum: " <> show x)
+instance GraphQLEnum CatCommandEnum
 
 type CatCommand = Enum "CatCommand" CatCommandEnum
 
@@ -120,9 +105,9 @@ tests = testSpec "Type" $ do
     it "encodes correctly" $ do
     getAnnotatedType @DogCommand `shouldBe`
        Right (TypeNonNull (NonNullTypeNamed (DefinedType (TypeDefinitionEnum (EnumTypeDefinition (unsafeMakeName "DogCommand")
-         [ EnumValueDefinition (unsafeMakeName "SIT")
-         , EnumValueDefinition (unsafeMakeName "DOWN")
-         , EnumValueDefinition (unsafeMakeName "HEEL")
+         [ EnumValueDefinition (unsafeMakeName "Sit")
+         , EnumValueDefinition (unsafeMakeName "Down")
+         , EnumValueDefinition (unsafeMakeName "Heel")
          ])))))
   describe "Union type" $
     it "encodes correctly" $ do

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -46,7 +46,7 @@ import GraphQL.Value (Value(..))
 data DogCommandEnum = Sit | Down | Heel
 
 instance GraphQLEnum DogCommandEnum where
-  enumValues _ = map makeName ["SIT", "DOWN", "HEEL"]
+  enumValues = map makeName ["SIT", "DOWN", "HEEL"]
   enumToValue _ = undefined
   enumFromValue (ValueEnum x) =
     case getNameText x of
@@ -78,7 +78,7 @@ type Human = Object "Human" '[Sentient] '[Field "name" Text]
 data CatCommandEnum = Jump
 
 instance GraphQLEnum CatCommandEnum where
-  enumValues _ = [makeName "JUMP"]
+  enumValues = [makeName "JUMP"]
   enumToValue = undefined
   enumFromValue (ValueEnum x)
     | getNameText x == "JUMP" = pure Jump

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -22,7 +22,7 @@ import GraphQL.API
   , getFieldDefinition
   , getInterfaceDefinition
   )
-import GraphQL.Internal.AST (getNameText, unsafeMakeName)
+import GraphQL.Internal.AST (getNameText, unsafeMakeName, makeName)
 import GraphQL.Internal.Schema
   ( EnumTypeDefinition(..)
   , EnumValueDefinition(..)
@@ -46,7 +46,7 @@ import GraphQL.Value (Value(..))
 data DogCommandEnum = Sit | Down | Heel
 
 instance GraphQLEnum DogCommandEnum where
-  enumValues _ = map unsafeMakeName ["SIT", "DOWN", "HEEL"]
+  enumValues _ = map makeName ["SIT", "DOWN", "HEEL"]
   enumToValue _ = undefined
   enumFromValue (ValueEnum x) =
     case getNameText x of
@@ -78,7 +78,7 @@ type Human = Object "Human" '[Sentient] '[Field "name" Text]
 data CatCommandEnum = Jump
 
 instance GraphQLEnum CatCommandEnum where
-  enumValues _ = [unsafeMakeName "JUMP"]
+  enumValues _ = [makeName "JUMP"]
   enumToValue = undefined
   enumFromValue (ValueEnum x)
     | getNameText x == "JUMP" = pure Jump


### PR DESCRIPTION
Rough implementation, has some nice properties though not encoded as well as they could be:

* calling `enumValues` fails if there is an invalid name (right now through an incomplete pattern match). `enumValues` is mostly internal so we can decide how we want to fail here. Should tie in with general validation.
* Checks for unary constructors and doesn't compile if it's not. (Try `instance GraphQLEnum A`)