### PR TITLE
Validation for values and variables, plus substitution

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -42,6 +42,7 @@ library
       GraphQL.Internal.Arbitrary
       GraphQL.Internal.AST
       GraphQL.Internal.Encoder
+      GraphQL.Internal.OrderedMap
       GraphQL.Internal.Output
       GraphQL.Internal.Parser
       GraphQL.Internal.Schema
@@ -69,6 +70,7 @@ test-suite graphql-api-doctests
       ASTTests
       Examples.FileSystem
       Examples.UnionExample
+      OrderedMapTests
       Spec
       TypeApiTests
       TypeTests
@@ -103,6 +105,7 @@ test-suite graphql-api-tests
       Doctests
       Examples.FileSystem
       Examples.UnionExample
+      OrderedMapTests
       TypeApiTests
       TypeTests
       ValidationTests

--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.14.1.
+-- This file has been generated from package.yaml by hpack version 0.15.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -42,6 +42,7 @@ library
       GraphQL.Internal.Arbitrary
       GraphQL.Internal.AST
       GraphQL.Internal.Encoder
+      GraphQL.Internal.Execution
       GraphQL.Internal.OrderedMap
       GraphQL.Internal.Output
       GraphQL.Internal.Parser

--- a/package.yaml
+++ b/package.yaml
@@ -9,7 +9,7 @@ github: jml/graphql-api
 category: Web
 
 # NB the "redundant constraints" warning is a GHC bug: https://ghc.haskell.org/trac/ghc/ticket/11099
-ghc-options: -Wall -fno-warn-redundant-constraints -Werror
+ghc-options: -Wall -fno-warn-redundant-constraints
 default-extensions:
   - NoImplicitPrelude
   - OverloadedStrings

--- a/package.yaml
+++ b/package.yaml
@@ -9,7 +9,7 @@ github: jml/graphql-api
 category: Web
 
 # NB the "redundant constraints" warning is a GHC bug: https://ghc.haskell.org/trac/ghc/ticket/11099
-ghc-options: -Wall -fno-warn-redundant-constraints
+ghc-options: -Wall -fno-warn-redundant-constraints -Werror
 default-extensions:
   - NoImplicitPrelude
   - OverloadedStrings

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -21,6 +21,7 @@ import GraphQL.Internal.Validation
   , ValidationErrors
   , validate
   , getSelectionSet
+  , VariableValue
   )
 
 -- | Errors that can happen while processing a query document.
@@ -35,7 +36,7 @@ data QueryError
   deriving (Eq, Show)
 
 -- | Turn some text into a valid query document.
-compileQuery :: Text -> Either QueryError (QueryDocument AST.Value)
+compileQuery :: Text -> Either QueryError (QueryDocument VariableValue)
 compileQuery query = do
   parsed <- first ParseError (parseQuery query)
   first ValidationError (validate parsed)

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -35,7 +35,7 @@ data QueryError
   deriving (Eq, Show)
 
 -- | Turn some text into a valid query document.
-compileQuery :: Text -> Either QueryError QueryDocument
+compileQuery :: Text -> Either QueryError (QueryDocument AST.Value)
 compileQuery query = do
   parsed <- first ParseError (parseQuery query)
   first ValidationError (validate parsed)
@@ -47,7 +47,7 @@ parseQuery query = first toS (parseOnly (Parser.queryDocument <* endOfInput) que
 -- | Get an operation from a query document ready to be processed.
 --
 -- TODO: This is the wrong API. For example, it doesn't take variable values.
-getOperation :: QueryDocument -> Maybe AST.Name -> Maybe SelectionSet
+getOperation :: QueryDocument value -> Maybe AST.Name -> Maybe (SelectionSet value)
 getOperation document name = do
   op <- GraphQL.Internal.Validation.getOperation document name
   pure (getSelectionSet op)

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -57,7 +57,8 @@ parseQuery query = first toS (parseOnly (Parser.queryDocument <* endOfInput) que
 
 -- | Get an operation from a query document ready to be processed.
 --
--- TODO: This is the wrong API. For example, it doesn't take variable values.
+-- TODO: Open question whether we want to export this to the end-user. If we
+-- do, it should probably not be in first position.
 getOperation :: QueryDocument VariableValue -> Maybe AST.Name -> VariableValues -> Either QueryError (SelectionSet Value)
 getOperation document name vars = first ExecutionError $ do
   op <- Execution.getOperation document name

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -251,15 +251,15 @@ data Directive = Directive Name [Argument] deriving (Eq,Show)
 data Type = TypeNamed NamedType
           | TypeList ListType
           | TypeNonNull NonNullType
-            deriving (Eq,Show)
+            deriving (Eq, Ord, Show)
 
-newtype NamedType = NamedType Name deriving (Eq,Show)
+newtype NamedType = NamedType Name deriving (Eq, Ord, Show)
 
-newtype ListType = ListType Type deriving (Eq,Show)
+newtype ListType = ListType Type deriving (Eq, Ord, Show)
 
 data NonNullType = NonNullTypeNamed NamedType
                  | NonNullTypeList  ListType
-                   deriving (Eq,Show)
+                   deriving (Eq, Ord, Show)
 
 -- * Type definition
 

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -160,7 +160,7 @@ nameFromSymbol = makeName (toS (symbolVal @n Proxy))
 data VariableDefinition = VariableDefinition Variable Type (Maybe DefaultValue)
                           deriving (Eq,Show)
 
-newtype Variable = Variable Name deriving (Eq,Show)
+newtype Variable = Variable Name deriving (Eq, Ord, Show)
 
 instance Arbitrary Variable where
   arbitrary = Variable <$> arbitrary

--- a/src/GraphQL/Internal/Execution.hs
+++ b/src/GraphQL/Internal/Execution.hs
@@ -103,7 +103,11 @@ formatError (MissingValue name) = "Missing value for " <> show name <> " and mus
 formatError (NoSuchOperation name) = "Requested operation " <> show name <> " but couldn't find it."
 formatError NoAnonymousOperation = "No name supplied for opertaion, but no anonymous operation."
 
--- | Variable values.
+-- | A map of variables to their values.
+--
+-- In GraphQL the variable values are not part of the query itself, they are
+-- instead passed in through a separate channel. Create a 'VariableValues'
+-- from this other channel and pass it to 'substituteVariables'.
 --
 -- GraphQL allows the values of variables to be specified, but doesn't provide
 -- a way for doing so in the language.

--- a/src/GraphQL/Internal/Execution.hs
+++ b/src/GraphQL/Internal/Execution.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
+-- | Implement the \"Execution\" part of the GraphQL spec.
+--
+-- Actually, most of the execution work takes place in 'GraphQL.Resolver', but
+-- there's still a fair bit required to glue together the results of
+-- 'GraphQL.Internal.Validation' and the processing in 'GraphQL.Resolver'.
+-- This module provides that glue.
+module GraphQL.Internal.Execution
+  ( VariableValues
+  , ExecutionError(..)
+  , formatError
+  , getOperation
+  , substituteVariables
+  ) where
+
+import Protolude hiding (Type)
+
+import qualified Data.Map as Map
+import GraphQL.Value
+  ( Name
+  , Value
+  , pattern ValueNull
+  , Value'(..)
+  , List'(..)
+  , Object'(..)
+  )
+import GraphQL.Internal.Validation
+  ( Operation
+  , QueryDocument(..)
+  , VariableDefinition(..)
+  , VariableValue
+  , Variable
+  , Type(..)
+  )
+
+-- Maybe we should have?
+--
+-- >>> data Request = Request Schema Document (Maybe Operation) (Maybe VariableValues) InitialValue
+--
+-- And then we can have:
+--
+-- execute :: Request -> m Response
+--
+-- Where 'Reponse' is from 'GraphQL.Internal.Output'.
+
+-- | Get an operation from a GraphQL document
+--
+-- <https://facebook.github.io/graphql/#sec-Executing-Requests>
+--
+-- GetOperation(document, operationName):
+--
+--   * If {operationName} is {null}:
+--     * If {document} contains exactly one operation.
+--       * Return the Operation contained in the {document}.
+--     * Otherwise produce a query error requiring {operationName}.
+--   * Otherwise:
+--     * Let {operation} be the Operation named {operationName} in {document}.
+--     * If {operation} was not found, produce a query error.
+--     * Return {operation}.
+getOperation :: QueryDocument value -> Maybe Name -> Either ExecutionError (Operation value)
+getOperation (LoneAnonymousOperation op) Nothing = pure op
+getOperation (MultipleOperations ops) (Just name) = note (NoSuchOperation name) (Map.lookup name ops)
+getOperation (MultipleOperations ops) Nothing =
+  case toList ops of
+    [op] -> pure op
+    _ -> throwError NoAnonymousOperation
+getOperation _ (Just name) = throwError (NoSuchOperation name)
+
+
+-- | Substitute variables in a GraphQL document.
+--
+-- Once this is done, there will be no variables in the document whatsoever.
+substituteVariables :: Operation VariableValue -> VariableValues -> Either ExecutionError (Operation Value)
+substituteVariables op vars = traverse (replaceVariable vars) op
+
+replaceVariable :: VariableValues -> VariableValue -> Either ExecutionError Value
+replaceVariable vars value =
+  case value of
+    ValueScalar' (Left defn) -> getValue defn
+    ValueScalar' (Right v) -> pure (ValueScalar' v)
+    ValueList' (List' xs) -> ValueList' . List' <$> traverse (replaceVariable vars) xs
+    ValueObject' (Object' xs) -> ValueObject' . Object' <$> traverse (replaceVariable vars) xs
+  where
+
+    getValue :: VariableDefinition -> Either ExecutionError Value
+    getValue (VariableDefinition variableName variableType defaultValue) =
+      note (MissingValue variableName) $
+      Map.lookup variableName vars <|> defaultValue <|> allowNull variableType
+
+    allowNull (TypeNonNull _) = empty
+    allowNull _ = pure ValueNull
+
+
+data ExecutionError
+  = MissingValue Variable
+  | NoSuchOperation Name
+  | NoAnonymousOperation
+  deriving (Eq, Show)
+
+formatError :: ExecutionError -> Text
+formatError (MissingValue name) = "Missing value for " <> show name <> " and must be non-null."
+formatError (NoSuchOperation name) = "Requested operation " <> show name <> " but couldn't find it."
+formatError NoAnonymousOperation = "No name supplied for opertaion, but no anonymous operation."
+
+-- | Variable values.
+--
+-- GraphQL allows the values of variables to be specified, but doesn't provide
+-- a way for doing so in the language.
+type VariableValues = Map Variable Value

--- a/src/GraphQL/Internal/OrderedMap.hs
+++ b/src/GraphQL/Internal/OrderedMap.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE RankNTypes #-}
+-- | Data structure for mapping keys to values while preserving order of appearance.
+--
+-- There are many cases in GraphQL where we want to have a map from names to
+-- values, where values can easily be lookup up by name and name is unique.
+-- This would normally be modelled as a 'Map'. However, in many of these
+-- cases, the order in which the entries appear matters.
+--
+-- That is,
+--
+-- @
+-- {
+--   'foo': 1,
+--   'bar': 2
+-- }
+-- @
+--
+-- Is different to,
+--
+-- @
+-- {
+--   'bar': 2,
+--   'foo': 1,
+-- }
+--
+-- Even though they have exactly the same keys, and the keys have exactly the
+-- same values.
+--
+-- Goal for this module is to provide data structures that are "complete
+-- enough" for implementing the rest of GraphQL.
+module GraphQL.Internal.OrderedMap
+  ( OrderedMap
+  -- * Construction
+  , empty
+  , singleton
+  , orderedMap
+  -- * Querying
+  , lookup
+  -- * Combine
+  -- ** Union
+  , unions
+  -- * Conversion
+  , toList
+  , toMap
+  , keys
+  , values
+  -- * Properties
+  , genOrderedMap
+  ) where
+
+import Protolude hiding (empty, toList)
+
+import qualified Data.Map as Map
+import Test.QuickCheck (Arbitrary(..), Gen, listOf)
+
+data OrderedMap key value
+  = OrderedMap
+    { -- | Get the list of keys from an ordered map, in order of appearance.
+      --
+      -- This list is guaranteed to have no duplicates.
+      keys :: [key]
+      -- | Convert an ordered map to a regular map, losing insertion order.
+    , toMap :: Map key value
+    }
+  deriving (Eq, Ord, Show)
+
+-- | Convert an ordered map to a list of keys and values. The list is
+-- guaranteed to be the same order as the order of insertion into the map.
+--
+-- /O(n log n)/
+toList :: forall key value. Ord key => OrderedMap key value -> [(key, value)]
+toList (OrderedMap keys entries) = catMaybes (foreach keys $ \k -> (,) k <$> Map.lookup k entries)
+
+instance Foldable (OrderedMap key) where
+  foldr f z (OrderedMap _ entries) = foldr f z entries
+
+instance Traversable (OrderedMap key) where
+  traverse f (OrderedMap keys entries) = OrderedMap keys <$> traverse f entries
+
+instance Functor (OrderedMap key) where
+  fmap f (OrderedMap keys entries) = OrderedMap keys (map f entries)
+
+instance (Arbitrary key, Arbitrary value, Ord key) => Arbitrary (OrderedMap key value) where
+  arbitrary = genOrderedMap arbitrary arbitrary
+
+-- | Generate an ordered map with the given key & value generators.
+genOrderedMap :: forall key value. Ord key => Gen key -> Gen value -> Gen (OrderedMap key value)
+genOrderedMap genKey genValue = do
+  entries <- Map.fromList <$> (zip <$> listOf genKey <*> listOf genValue)
+  pure (OrderedMap (Map.keys entries) entries)
+
+-- | The empty OrderedMap. /O(1)/
+empty :: forall key value. OrderedMap key value
+empty = OrderedMap [] Map.empty
+
+-- | Create an ordered map containing a single entry. /O(1)/
+singleton :: forall key value. key -> value -> OrderedMap key value
+singleton key value = OrderedMap [key] (Map.singleton key value)
+
+-- | Find a value in an ordered map.
+--
+-- /O(log n)/
+lookup :: forall key value. Ord key => key -> OrderedMap key value -> Maybe value
+lookup key (OrderedMap _ entries) = Map.lookup key entries
+
+-- | Get the values from an ordered map, in order of appearance. /O(n log n)/
+values :: forall key value. Ord key => OrderedMap key value -> [value]
+values = map snd . toList
+
+-- | The union of a list of ordered maps.
+--
+-- If any map shares a key with any other map, return 'Nothing'.
+--
+-- Otherwise, return a new map containing all of the keys from all of the
+-- maps. The keys from the first map will appear first, followed by the
+-- second, and so forth.
+--
+-- /O(m * n log (m * n))/ where /m/ is the number of maps, and /n/ is the size of
+-- the largest map.
+unions :: forall key value. Ord key => [OrderedMap key value] -> Maybe (OrderedMap key value)
+unions orderedMaps = orderedMap (orderedMaps >>= toList)
+
+-- | Construct an ordered map from a list.
+--
+-- /O(n log n)/.
+--
+-- If the list contains duplicate keys, then return 'Nothing'. Otherwise,
+-- return an 'OrderedMap', preserving the order.
+orderedMap :: forall key value. Ord key => [(key, value)] -> Maybe (OrderedMap key value)
+orderedMap entries
+  | ks == ordNub ks = Just (OrderedMap ks (Map.fromList entries))
+  | otherwise = Nothing
+  where
+    ks = map fst entries

--- a/src/GraphQL/Internal/Output.hs
+++ b/src/GraphQL/Internal/Output.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PatternSynonyms #-}
 -- | GraphQL output.
 --
 -- How we encode GraphQL responses.
@@ -13,7 +14,9 @@ import GraphQL.Value
   ( Object
   , objectFromList
   , ToValue(..)
-  , Value(ValueObject, ValueNull)
+  , Value
+  , pattern ValueObject
+  , pattern ValueNull
   )
 import GraphQL.Internal.AST (unsafeMakeName)
 

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -124,7 +124,7 @@ getSelectionSet (Query _ _ ss) = ss
 getSelectionSet (Mutation _ _ ss) = ss
 
 -- | Type alias for 'Query' and 'Mutation' constructors of 'Operation'.
-type OperationType value = VariableDefinitions -> (Directives value) -> (SelectionSet value) -> (Operation value)
+type OperationType value = VariableDefinitions -> Directives value -> SelectionSet value -> Operation value
 
 type Operations value = Map Name (Operation value)
 
@@ -506,7 +506,7 @@ validateVariableDefinitions vars = do
 -- | Ensure that a variable definition is a valid one.
 validateVariableDefinition :: AST.VariableDefinition -> Validation VariableDefinition
 validateVariableDefinition (AST.VariableDefinition name varType value) =
-  VariableDefinition name varType <$> (traverse validateDefaultValue value)
+  VariableDefinition name varType <$> traverse validateDefaultValue value
 
 -- | Ensure that a default value contains no variables.
 validateDefaultValue :: AST.DefaultValue -> Validation Value
@@ -539,7 +539,7 @@ validateValues = traverse toVariableValue
 resolveVariables :: Traversable f => VariableDefinitions -> f UnresolvedVariableValue -> Validation (f VariableValue)
 resolveVariables definitions = traverse resolveVariableValue
   where
-    resolveVariableValue value = traverse resolveVariable value
+    resolveVariableValue = traverse resolveVariable
     resolveVariable (Left variable) =
       case Map.lookup variable definitions of
         Nothing -> throwE (UndefinedVariable variable)

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -187,7 +187,9 @@ validateOperations fragments ops = do
   Operations <$> traverse validateNode deduped
   where
     validateNode (operationType, AST.Node _ vars directives ss) =
-      operationType <$> lift (validateVariables vars) <*> lift (validateDirectives directives) <*> validateSelectionSet fragments ss
+      operationType <$> lift (validateVariableDefinitions vars)
+                    <*> lift (validateDirectives directives)
+                    <*> validateSelectionSet fragments ss
 
 -- * Arguments
 
@@ -458,13 +460,14 @@ resolveFragmentDefinitions allFragments =
 
 -- * Variables
 
+-- TODO: Need to parametrise this by value and validate.
 newtype VariableDefinitions = VariableDefinitions (Map Variable AST.VariableDefinition) deriving (Eq, Show)
 
 emptyVariableDefinitions :: VariableDefinitions
 emptyVariableDefinitions = VariableDefinitions mempty
 
-validateVariables :: [AST.VariableDefinition] -> Validation VariableDefinitions
-validateVariables vars = VariableDefinitions <$> mapErrors DuplicateVariableDefinition (makeMap items)
+validateVariableDefinitions :: [AST.VariableDefinition] -> Validation VariableDefinitions
+validateVariableDefinitions vars = VariableDefinitions <$> mapErrors DuplicateVariableDefinition (makeMap items)
   where
     items = [(name, defn) | defn@(AST.VariableDefinition name _ _) <- vars]
 

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -303,7 +303,7 @@ validateSelection selection =
 -- We're doing a standard depth-first traversal of fragment references, where
 -- references are by name, so the set of names can be thought of as a record
 -- of visited references.
-resolveSelection :: Fragments value2 -> Selection' (UnresolvedFragmentSpread value2) value1 -> StateT (Set Name) Validation (Selection' (FragmentSpread value2) value1)
+resolveSelection :: Fragments a -> Selection' (UnresolvedFragmentSpread a) b -> StateT (Set Name) Validation (Selection' (FragmentSpread a) b)
 resolveSelection fragments = traverseFragmentSpreads resolveFragmentSpread
   where
     resolveFragmentSpread (UnresolvedFragmentSpread name directive) = do
@@ -336,7 +336,7 @@ type Fragments value = Map Name (FragmentDefinition (FragmentSpread value) value
 -- and directives are sane.
 --
 -- <https://facebook.github.io/graphql/#sec-Fragment-Name-Uniqueness>
-validateFragmentDefinitions :: [AST.FragmentDefinition] -> Validation (Map Name (FragmentDefinition (UnresolvedFragmentSpread AST.Value) AST.Value ))
+validateFragmentDefinitions :: [AST.FragmentDefinition] -> Validation (Map Name (FragmentDefinition (UnresolvedFragmentSpread AST.Value) AST.Value))
 validateFragmentDefinitions frags = do
   defns <- traverse validateFragmentDefinition frags
   mapErrors DuplicateFragmentDefinition (makeMap [(name, value) | value@(FragmentDefinition name _ _ _) <- defns])

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -13,6 +13,9 @@
 -- Still missing:
 --
 --   * variable validation <https://facebook.github.io/graphql/#sec-Validation.Variables>
+--     * variable uniqueness <https://facebook.github.io/graphql/#sec-Variable-Uniqueness>
+--     * all variable uses defined <https://facebook.github.io/graphql/#sec-All-Variable-Uses-Defined>
+--     * all variables used <https://facebook.github.io/graphql/#sec-All-Variables-Used>
 --   * field selection merging <https://facebook.github.io/graphql/#sec-Field-Selection-Merging>
 --   * input object field uniqueness <https://facebook.github.io/graphql/#sec-Values>
 --

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -475,7 +475,15 @@ resolveFragmentDefinitions allFragments =
 
 -- * Variables
 
-data VariableDefinition = VariableDefinition Variable AST.Type (Maybe Value) deriving (Eq, Ord, Show)
+-- | Defines a variable within the context of an operation.
+--
+-- See <https://facebook.github.io/graphql/#sec-Language.Variables>
+data VariableDefinition
+  = VariableDefinition
+    { variable :: Variable -- ^ The name of the variable
+    , variableType :: AST.Type -- ^ The type of the variable
+    , defaultValue :: Maybe Value -- ^ An optional default value for the variable
+    } deriving (Eq, Ord, Show)
 
 type VariableDefinitions = Map Variable VariableDefinition
 
@@ -492,7 +500,7 @@ emptyVariableDefinitions = mempty
 validateVariableDefinitions :: [AST.VariableDefinition] -> Validation VariableDefinitions
 validateVariableDefinitions vars = do
   validatedDefns <- traverse validateVariableDefinition vars
-  let items = [ (name, defn) | defn@(VariableDefinition name _ _) <- validatedDefns]
+  let items = [ (variable defn, defn) | defn <- validatedDefns]
   mapErrors DuplicateVariableDefinition (makeMap items)
 
 -- | Ensure that a variable definition is a valid one.

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE KindSignatures #-}
 -- | Transform GraphQL query documents from AST into valid structures
 --
@@ -505,9 +506,10 @@ validateDefaultValue defaultValue =
   case astToVariableValue defaultValue of
     Nothing -> throwE $ InvalidValue defaultValue
     Just value ->
-      for value $ \scalar -> case scalar of
-                               Left _ -> throwE $ InvalidDefaultValue defaultValue
-                               Right constant -> pure constant
+      for value $
+      \case
+        Left _ -> throwE $ InvalidDefaultValue defaultValue
+        Right constant -> pure constant
 
 
 -- | Get all the variables referred to in a thing what contains variables.

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -41,6 +41,7 @@ import GraphQL.API
   )
 import qualified GraphQL.API as API
 import qualified GraphQL.Value as GValue
+import GraphQL.Value (Value)
 import qualified GraphQL.Internal.AST as AST
 import GraphQL.Internal.Schema (HasName(..))
 import GraphQL.Internal.Validation
@@ -49,7 +50,6 @@ import GraphQL.Internal.Validation
   , InlineFragment(..)
   , FragmentSpread
   , Field
-  , VariableValue
   , getFields
   , getFieldSelectionSet
   , lookupArgument
@@ -60,22 +60,19 @@ data ResolverError
   -- | There was a problem in the schema. Server-side problem.
   = SchemaError AST.NameError
   -- | Couldn't find the requested field in the object. A client-side problem.
-  | FieldNotFoundError (Field VariableValue)
+  | FieldNotFoundError (Field Value)
   -- | No value provided for name, and no default specified. Client-side problem.
   | ValueMissing Name
   -- | Could not translate value into Haskell. Probably a client-side problem.
   | InvalidValue Name Text
   -- | Found duplicate fields in set.
   | DuplicateFields [ResolveFieldResult]
-  -- | We found a variable in an input value. We should only have constants at
-  -- this point.
-  | UnresolvedVariable Name VariableValue
   -- | We tried to resolve something that wasn't a union type despite
   -- expecting one.
-  | ResolveNonUnionType Text (SelectionSet VariableValue)
+  | ResolveNonUnionType Text (SelectionSet Value)
   -- | We tried to use an inline fragment with a name that the union
   -- type does not support.
-  | UnionTypeNotFound Text (SelectionSet VariableValue)
+  | UnionTypeNotFound Text (SelectionSet Value)
   deriving (Show, Eq)
 
 -- | Object field separation operator.
@@ -109,20 +106,20 @@ data Result a = Result [ResolverError] a deriving (Show, Functor, Eq)
 
 -- Aggregating results keeps all errors and creates a ValueList
 -- containing the individual values.
-aggregateResults :: [Result GValue.Value] -> Result GValue.Value
+aggregateResults :: [Result Value] -> Result Value
 aggregateResults r = GValue.toValue <$> sequenceA r
 
 instance Applicative Result where
   pure v = Result [] v
   (Result e1 f) <*> (Result e2 x) = Result (e1 <> e2) (f x)
 
-ok :: GValue.Value -> Result GValue.Value
+ok :: Value -> Result Value
 ok = pure
 
 
 class HasGraph m a where
   type Handler m a
-  buildResolver :: Handler m a -> SelectionSet VariableValue -> m (Result GValue.Value)
+  buildResolver :: Handler m a -> SelectionSet Value -> m (Result Value)
 
 -- | Specify a default value for a type in a GraphQL schema.
 --
@@ -186,15 +183,6 @@ instance forall m ks enum. (Applicative m, API.GraphQLEnum enum) => HasGraph m (
   buildResolver handler _ = (pure . ok . GValue.ValueEnum . API.enumToValue) handler
 
 
--- TODO: lookup is O(N log N) in number of arguments (we linearly search each
--- argument in the list) but considering the graphql use case where N usually
--- < 10 this is probably OK.
-lookupValue :: Name -> Field VariableValue -> Maybe GValue.Value
-lookupValue name field = do
-  value <- lookupArgument field name
-  -- If it's a variable, just return Nothing, as if the value isn't there.
-  traverse hush value
-
 -- TODO: variables should error, they should have been resolved already.
 --
 -- TODO: Objects. Maybe implement some Generic object reader? I.e. if I do
@@ -208,21 +196,21 @@ lookupValue name field = do
 -- the name matches the query. Note that the name is *not* in monad m,
 -- but the value is. This is necessary so we can skip execution if the
 -- name doesn't match.
-data NamedValueResolver m = NamedValueResolver Name (m (Result GValue.Value))
+data NamedValueResolver m = NamedValueResolver Name (m (Result Value))
 
 -- Iterate through handlers (zipped together with their type
 -- definition) and execute handler if the name matches.
 type ResolveFieldResult = Result (Maybe GValue.ObjectField)
 
 resolveField :: forall a (m :: Type -> Type). (BuildFieldResolver m a, Monad m)
-  => FieldHandler m a -> m ResolveFieldResult -> Field VariableValue -> m ResolveFieldResult
+  => FieldHandler m a -> m ResolveFieldResult -> Field Value -> m ResolveFieldResult
 resolveField handler nextHandler field =
   case buildFieldResolver @m @a handler field of
     -- TODO the fact that this doesn't fit together nicely makes me think that ObjectField is not a good idea)
     Left err -> pure (Result [err] (Just (GValue.ObjectField queryFieldName GValue.ValueNull)))
     Right (NamedValueResolver name' resolver) -> runResolver name' resolver
   where
-    runResolver :: Name -> m (Result GValue.Value) -> m ResolveFieldResult
+    runResolver :: Name -> m (Result Value) -> m ResolveFieldResult
     runResolver name' resolver
       | queryFieldName == name' = do
           Result errs value <- resolver
@@ -237,7 +225,7 @@ type family FieldHandler m (a :: Type) :: Type where
   FieldHandler m (API.Argument ks t :> f) = t -> FieldHandler m f
 
 class BuildFieldResolver m a where
-  buildFieldResolver :: FieldHandler m a -> Field VariableValue -> Either ResolverError (NamedValueResolver m)
+  buildFieldResolver :: FieldHandler m a -> Field Value -> Either ResolverError (NamedValueResolver m)
 
 instance forall ks t m. (KnownSymbol ks, HasGraph m t, HasAnnotatedType t, Monad m) => BuildFieldResolver m (API.Field ks t) where
   buildFieldResolver handler field = do
@@ -258,7 +246,7 @@ instance forall ks t f m.
   buildFieldResolver handler field = do
     argument <- first SchemaError (API.getArgumentDefinition @(API.Argument ks t))
     let argName = getName argument
-    value <- case lookupValue argName field of
+    value <- case lookupArgument field argName of
       Nothing -> valueMissing @t argName
       Just v -> first (InvalidValue argName) (GValue.fromValue @t v)
     buildFieldResolver @m @f (handler value) field
@@ -285,7 +273,7 @@ type family RunFieldsHandler (m :: Type -> Type) (a :: Type) = (r :: Type) where
 class RunFields m a where
   -- runFields is run on a single AST.Selection so it can only ever
   -- return one ObjectField.
-  runFields :: RunFieldsHandler m a -> Field VariableValue -> m ResolveFieldResult
+  runFields :: RunFieldsHandler m a -> Field Value -> m ResolveFieldResult
 
 instance forall f fs m.
          ( BuildFieldResolver m f
@@ -372,7 +360,7 @@ type role DynamicUnionValue representational representational
 data DynamicUnionValue (union :: Type) (m :: Type -> Type) = DynamicUnionValue { _label :: Text, _value :: GHC.Exts.Any }
 
 class RunUnion m union objects where
-  runUnion :: DynamicUnionValue union m -> InlineFragment FragmentSpread VariableValue -> m (Result GValue.Value)
+  runUnion :: DynamicUnionValue union m -> InlineFragment FragmentSpread Value -> m (Result Value)
 
 instance forall m union objects name interfaces fields.
   ( Monad m

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -191,8 +191,10 @@ instance forall m ks enum. (Applicative m, API.GraphQLEnum enum) => HasGraph m (
 -- argument in the list) but considering the graphql use case where N usually
 -- < 10 this is probably OK.
 lookupValue :: AST.Name -> Field AST.Value -> Maybe GValue.Value
-lookupValue name field = GValue.astToValue =<< lookupArgument field name
-
+lookupValue name field = do
+  ast <- lookupArgument field name
+  variable <- GValue.astToVariableValue ast
+  traverse hush variable
 
 -- TODO: variables should error, they should have been resolved already.
 --

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -1,19 +1,29 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Literal GraphQL values.
 module GraphQL.Value
-  ( Value(..)
+  ( Value
+  , pattern ValueInt
+  , pattern ValueFloat
+  , pattern ValueBoolean
+  , pattern ValueString
+  , pattern ValueEnum
+  , pattern ValueList
+  , pattern ValueObject
+  , pattern ValueNull
   , toObject
   , ToValue(..)
-  , astToValue
   , valueToAST
-  , prop_roundtripFromAST
-  , prop_roundtripFromValue
+  , astToVariableValue
+  , variableValueToAST
   , prop_roundtripValue
   , FromValue(..)
   , Name
@@ -21,7 +31,8 @@ module GraphQL.Value
   , String(..)
     -- * Objects
   , Object
-  , ObjectField(ObjectField)
+  , ObjectField
+  , ObjectField'(ObjectField)
     -- ** Constructing
   , makeObject
   , objectFromList
@@ -33,71 +44,161 @@ module GraphQL.Value
 
 import Protolude
 
+import qualified Data.Aeson as Aeson
+import Data.Aeson (ToJSON(..), (.=), pairs)
 import qualified Data.List.NonEmpty as NonEmpty
 import Data.List.NonEmpty (NonEmpty)
-import Data.Aeson (ToJSON(..), (.=), pairs)
-import qualified Data.Aeson as Aeson
 import qualified Data.Map as Map
 import Test.QuickCheck (Arbitrary(..), Gen, oneof, listOf, sized)
 
 import GraphQL.Internal.Arbitrary (arbitraryText)
-import GraphQL.Internal.AST (Name(..))
+import GraphQL.Internal.AST (Name(..), Variable)
 import qualified GraphQL.Internal.AST as AST
 import GraphQL.Internal.OrderedMap (OrderedMap)
 import qualified GraphQL.Internal.OrderedMap as OrderedMap
 
 
--- | Concrete GraphQL value. Essentially Data.GraphQL.AST.Value, but without
--- the "variable" field.
-data Value
-  = ValueInt Int32
-  | ValueFloat Double
-  | ValueBoolean Bool
-  | ValueString String
-  | ValueEnum Name
-  | ValueList List
-  | ValueObject Object
-  | ValueNull
-  deriving (Eq, Ord, Show)
+-- * Values
 
-toObject :: Value -> Maybe Object
-toObject (ValueObject o) = pure o
-toObject _ = empty
+-- | A GraphQL value. @scalar@ represents the type of scalar that's contained
+-- within this value.
+--
+-- Normally, it is one of either 'ConstScalar' (to indicate that there are no
+-- variables whatsoever) or 'VariableScalar' (to indicate that there might be
+-- some variables)
+data Value' scalar
+  = ValueScalar' scalar
+  | ValueList' (List' scalar)
+  | ValueObject' (Object' scalar)
+  deriving (Eq, Ord, Show, Functor)
 
-instance ToJSON GraphQL.Value.Value where
+instance Foldable Value' where
+  foldMap f (ValueScalar' scalar) = f scalar
+  foldMap f (ValueList' (List' values)) = mconcat (map (foldMap f) values)
+  foldMap f (ValueObject' (Object' fieldMap)) = foldMap (foldMap f) fieldMap
 
-  toJSON (ValueInt x) = toJSON x
-  toJSON (ValueFloat x) = toJSON x
-  toJSON (ValueBoolean x) = toJSON x
-  toJSON (ValueString x) = toJSON x
-  toJSON (ValueEnum x) = toJSON x
-  toJSON (ValueList x) = toJSON x
-  toJSON (ValueObject x) = toJSON x
-  toJSON ValueNull = Aeson.Null
+instance Traversable Value' where
+  traverse f (ValueScalar' x) = ValueScalar' <$> f x
+  traverse f (ValueList' (List' xs)) = ValueList' . List' <$> traverse (traverse f) xs
+  traverse f (ValueObject' (Object' xs)) = ValueObject' . Object' <$> traverse (traverse f) xs
 
-instance Arbitrary Value where
+instance ToJSON scalar => ToJSON (Value' scalar) where
+  toJSON (ValueScalar' x) = toJSON x
+  toJSON (ValueList' x) = toJSON x
+  toJSON (ValueObject' x) = toJSON x
+
+instance Arbitrary scalar => Arbitrary (Value' scalar) where
   -- | Generate an arbitrary value. Uses the generator's \"size\" property to
   -- determine maximum object depth.
   arbitrary = sized genValue
 
--- | Generate an arbitrary scalar value.
-genScalarValue :: Gen Value
-genScalarValue = oneof [ ValueInt <$> arbitrary
-                       , ValueFloat <$> arbitrary
-                       , ValueBoolean <$> arbitrary
-                       , ValueString <$> arbitrary
-                       , ValueEnum <$> arbitrary
-                       , pure ValueNull
-                       ]
-
 -- | Generate an arbitrary value, with objects at most @n@ levels deep.
-genValue :: Int -> Gen Value
+genValue :: Arbitrary scalar => Int -> Gen (Value' scalar)
 genValue n
-  | n <= 0 = genScalarValue
-  | otherwise = oneof [ genScalarValue
-                      , ValueObject <$> genObject (n - 1)
-                      , ValueList . List <$> listOf (genValue (n - 1))
+  | n <= 0 = arbitrary
+  | otherwise = oneof [ ValueScalar' <$> arbitrary
+                      , ValueObject' <$> genObject (n - 1)
+                      , ValueList' . List' <$> listOf (genValue (n - 1))
                       ]
+
+-- | A GraphQL value which contains no variables.
+type Value = Value' ConstScalar
+
+-- | A GraphQL value which might contain some variables.
+type VariableValue = Value' VariableScalar
+
+pattern ValueInt :: Int32 -> Value
+pattern ValueInt x = ValueScalar' (ConstInt x)
+
+pattern ValueFloat :: Double -> Value
+pattern ValueFloat x = ValueScalar' (ConstFloat x)
+
+pattern ValueBoolean :: Bool -> Value
+pattern ValueBoolean x = ValueScalar' (ConstBoolean x)
+
+pattern ValueString :: String -> Value
+pattern ValueString x = ValueScalar' (ConstString x)
+
+pattern ValueEnum :: Name -> Value
+pattern ValueEnum x = ValueScalar' (ConstEnum x)
+
+pattern ValueList :: forall t. List' t -> Value' t
+pattern ValueList x = ValueList' x
+
+pattern ValueObject :: forall t. Object' t -> Value' t
+pattern ValueObject x = ValueObject' x
+
+pattern ValueNull :: Value
+pattern ValueNull = ValueScalar' ConstNull
+
+-- | If a value is an object, return just that. Otherwise @Nothing@.
+toObject :: Value' scalar -> Maybe (Object' scalar)
+toObject (ValueObject' o) = pure o
+toObject _ = empty
+
+-- * Scalars
+
+-- | A non-variable value which contains no other values.
+data ConstScalar
+  = ConstInt Int32
+  | ConstFloat Double
+  | ConstBoolean Bool
+  | ConstString String
+  | ConstEnum Name
+  | ConstNull
+  deriving (Eq, Ord, Show)
+
+instance ToJSON ConstScalar where
+  toJSON (ConstInt x) = toJSON x
+  toJSON (ConstFloat x) = toJSON x
+  toJSON (ConstBoolean x) = toJSON x
+  toJSON (ConstString x) = toJSON x
+  toJSON (ConstEnum x) = toJSON x
+  toJSON ConstNull = Aeson.Null
+
+-- | A value which contains no other values, and might be a variable.
+type VariableScalar = Either Variable ConstScalar
+
+-- | Generate an arbitrary scalar value.
+instance Arbitrary ConstScalar where
+  arbitrary = oneof [ ConstInt <$> arbitrary
+                    , ConstFloat <$> arbitrary
+                    , ConstBoolean <$> arbitrary
+                    , ConstString <$> arbitrary
+                    , ConstEnum <$> arbitrary
+                    , pure ConstNull
+                    ]
+
+-- | Convert a constant scalar to an AST.Value
+constToAST :: ConstScalar -> AST.Value
+constToAST scalar =
+  case scalar of
+    ConstInt x -> AST.ValueInt x
+    ConstFloat x -> AST.ValueFloat x
+    ConstBoolean x -> AST.ValueBoolean x
+    ConstString (String x) -> AST.ValueString (AST.StringValue x)
+    ConstEnum x -> AST.ValueEnum x
+    ConstNull -> AST.ValueNull
+
+-- | Convert a variable scalar to an AST.Value
+variableToAST :: VariableScalar -> AST.Value
+variableToAST (Left variable) = AST.ValueVariable variable
+variableToAST (Right constant) = constToAST constant
+
+-- | Convert a value from the AST into a variable scalar, presuming it /is/ a
+-- scalar.
+astToScalar :: AST.Value -> Maybe VariableScalar
+astToScalar (AST.ValueInt x) = pure $ Right $ ConstInt x
+astToScalar (AST.ValueFloat x) = pure $ Right $ ConstFloat x
+astToScalar (AST.ValueBoolean x) = pure $ Right $ ConstBoolean x
+astToScalar (AST.ValueString (AST.StringValue x)) = pure $ Right $ ConstString (String x)
+astToScalar (AST.ValueEnum x) = pure $ Right $ ConstEnum x
+astToScalar AST.ValueNull = pure $ Right ConstNull
+astToScalar (AST.ValueVariable x) = pure $ Left x
+astToScalar _ = empty
+
+
+-- * Strings
 
 newtype String = String Text deriving (Eq, Ord, Show)
 
@@ -107,94 +208,118 @@ instance Arbitrary String where
 instance ToJSON String where
   toJSON (String x) = toJSON x
 
-newtype List = List [Value] deriving (Eq, Ord, Show)
+-- * Lists
 
-instance Arbitrary List where
+newtype List' scalar = List' [Value' scalar] deriving (Eq, Ord, Show, Functor)
+
+-- | A list of values that are known to be constants.
+--
+-- Note that this list might not be valid GraphQL, because GraphQL only allows
+-- homogeneous lists (i.e. all elements of the same type), and we do no type
+-- checking at this point.
+type List = List' ConstScalar
+
+instance Arbitrary scalar => Arbitrary (List' scalar) where
   -- TODO: GraphQL does not allow heterogeneous lists:
   -- https://facebook.github.io/graphql/#sec-Lists, so this will generate
   -- invalid lists.
-  arbitrary = List <$> listOf arbitrary
+  arbitrary = List' <$> listOf arbitrary
 
 makeList :: (Functor f, Foldable f, ToValue a) => f a -> List
-makeList = List . Protolude.toList . map toValue
+makeList = List' . Protolude.toList . map toValue
 
 
-instance ToJSON List where
-  toJSON (List x) = toJSON x
+instance ToJSON scalar => ToJSON (List' scalar) where
+  toJSON (List' x) = toJSON x
 
--- | A literal GraphQL object.
+-- * Objects
+
+-- | A GraphQL object.
 --
 -- Note that https://facebook.github.io/graphql/#sec-Response calls these
 -- \"Maps\", but everywhere else in the spec refers to them as objects.
-newtype Object = Object (OrderedMap Name Value) deriving (Eq, Ord, Show)
+newtype Object' scalar = Object' (OrderedMap Name (Value' scalar)) deriving (Eq, Ord, Show, Functor)
 
-objectFields :: Object -> [ObjectField]
-objectFields (Object object) = map (uncurry ObjectField) (OrderedMap.toList object)
+-- | A GraphQL object that contains only non-variable values.
+type Object = Object' ConstScalar
 
-instance Arbitrary Object where
+objectFields :: Object' scalar -> [ObjectField' scalar]
+objectFields (Object' object) = map (uncurry ObjectField') (OrderedMap.toList object)
+
+instance Arbitrary scalar => Arbitrary (Object' scalar) where
   arbitrary = sized genObject
 
 -- | Generate an arbitrary object to the given maximum depth.
-genObject :: Int -> Gen Object
-genObject n = Object <$> OrderedMap.genOrderedMap arbitrary (genValue n)
+genObject :: Arbitrary scalar => Int -> Gen (Object' scalar)
+genObject n = Object' <$> OrderedMap.genOrderedMap arbitrary (genValue n)
 
-data ObjectField = ObjectField Name Value deriving (Eq, Ord, Show)
+data ObjectField' scalar = ObjectField' Name (Value' scalar) deriving (Eq, Ord, Show, Functor)
 
-instance Arbitrary ObjectField where
-  arbitrary = ObjectField <$> arbitrary <*> arbitrary
+-- | A field of an object that has a non-variable value.
+type ObjectField = ObjectField' ConstScalar
 
-makeObject :: [ObjectField] -> Maybe Object
-makeObject fields = objectFromList [(name, value) | ObjectField name value <- fields]
+pattern ObjectField :: forall t. Name -> Value' t -> ObjectField' t
+pattern ObjectField name value = ObjectField' name value
 
-objectFromList :: [(Name, Value)] -> Maybe Object
-objectFromList xs = Object <$> OrderedMap.orderedMap xs
+instance Arbitrary scalar => Arbitrary (ObjectField' scalar) where
+  arbitrary = ObjectField' <$> arbitrary <*> arbitrary
 
-unionObjects :: [Object] -> Maybe Object
-unionObjects objects = Object <$> OrderedMap.unions [obj | Object obj <- objects]
+-- | Make an object from a list of object fields.
+makeObject :: [ObjectField' scalar] -> Maybe (Object' scalar)
+makeObject fields = objectFromList [(name, value) | ObjectField' name value <- fields]
 
-instance ToJSON Object where
+-- | Create an object from a list of (name, value) pairs.
+objectFromList :: [(Name, Value' scalar)] -> Maybe (Object' scalar)
+objectFromList xs = Object' <$> OrderedMap.orderedMap xs
+
+unionObjects :: [Object' scalar] -> Maybe (Object' scalar)
+unionObjects objects = Object' <$> OrderedMap.unions [obj | Object' obj <- objects]
+
+instance ToJSON scalar => ToJSON (Object' scalar) where
   -- Direct encoding to preserve order of keys / values
-  toJSON (Object xs) = toJSON (Map.fromList [(getNameText k, v) | (k, v) <- OrderedMap.toList xs])
-  toEncoding (Object xs) = pairs (foldMap (\(k, v) -> toS (getNameText k) .= v) (OrderedMap.toList xs))
+  toJSON (Object' xs) = toJSON (Map.fromList [(getNameText k, v) | (k, v) <- OrderedMap.toList xs])
+  toEncoding (Object' xs) = pairs (foldMap (\(k, v) -> toS (getNameText k) .= v) (OrderedMap.toList xs))
+
+
+-- * ToValue
 
 -- | Turn a Haskell value into a GraphQL value.
 class ToValue a where
-  toValue :: a -> Value
+  toValue :: a -> Value' ConstScalar
 
-instance ToValue Value where
+instance ToValue (Value' ConstScalar) where
   toValue = identity
 
 -- XXX: Should this just be for Foldable?
 instance ToValue a => ToValue [a] where
-  toValue = toValue . List . map toValue
+  toValue = toValue . List' . map toValue
 
 instance ToValue a => ToValue (NonEmpty a) where
   toValue = toValue . makeList
 
-instance ToValue a => ToValue (Maybe a) where
-  toValue = maybe ValueNull toValue
-
 instance ToValue Bool where
-  toValue = ValueBoolean
+  toValue = ValueScalar' . ConstBoolean
 
 instance ToValue Int32 where
-  toValue = ValueInt
+  toValue = ValueScalar' . ConstInt
 
 instance ToValue Double where
-  toValue = ValueFloat
+  toValue = ValueScalar' . ConstFloat
 
 instance ToValue String where
-  toValue = ValueString
+  toValue = ValueScalar' . ConstString
 
 -- XXX: Make more generic: any string-like thing rather than just Text.
 instance ToValue Text where
   toValue = toValue . String
 
 instance ToValue List where
-  toValue = ValueList
+  toValue = ValueList'
 
-instance ToValue Object where
-  toValue = ValueObject
+instance ToValue (Object' ConstScalar) where
+  toValue = ValueObject'
+
+-- * FromValue
 
 -- | @a@ can be converted from a GraphQL 'Value' to a Haskell value.
 --
@@ -204,37 +329,37 @@ instance ToValue Object where
 class FromValue a where
   -- | Convert an already-parsed value into a Haskell value, generally to be
   -- passed to a handler.
-  fromValue :: Value -> Either Text a
+  fromValue :: Value' ConstScalar -> Either Text a
 
 instance FromValue Int32 where
-  fromValue (ValueInt v) = pure v
+  fromValue (ValueScalar' (ConstInt v)) = pure v
   fromValue v = wrongType "Int" v
 
 instance FromValue Double where
-  fromValue (ValueFloat v) = pure v
+  fromValue (ValueScalar' (ConstFloat v)) = pure v
   fromValue v = wrongType "Double" v
 
 instance FromValue Bool where
-  fromValue (ValueBoolean v) = pure v
+  fromValue (ValueScalar' (ConstBoolean v)) = pure v
   fromValue v = wrongType "Bool" v
 
 instance FromValue Text where
-  fromValue (ValueString (String v)) = pure v
+  fromValue (ValueScalar' (ConstString (String v))) = pure v
   fromValue v = wrongType "String" v
 
 instance forall v. FromValue v => FromValue [v] where
-  fromValue (ValueList (List values)) = traverse (fromValue @v) values
+  fromValue (ValueList' (List' values)) = traverse (fromValue @v) values
   fromValue v = wrongType "List" v
 
 instance forall v. FromValue v => FromValue (NonEmpty v) where
-  fromValue (ValueList (List values)) =
+  fromValue (ValueList' (List' values)) =
     case NonEmpty.nonEmpty values of
       Nothing -> Left "Cannot construct NonEmpty from empty list"
       Just values' -> traverse (fromValue @v) values'
   fromValue v = wrongType "List" v
 
 instance forall v. FromValue v => FromValue (Maybe v) where
-  fromValue ValueNull = pure Nothing
+  fromValue (ValueScalar' ConstNull) = pure Nothing
   fromValue x = Just <$> fromValue @v x
 
 -- | Anything that can be converted to a value and from a value should roundtrip.
@@ -245,32 +370,47 @@ prop_roundtripValue x = fromValue (toValue x) == Right x
 wrongType :: (MonadError Text m, Show a) => Text -> a -> m b
 wrongType expected value = throwError ("Wrong type, should be " <> expected <> show value)
 
+-- * Conversion to and from AST.
+
 -- | Convert an AST value into a literal value.
 --
 -- This is a stop-gap until we have proper conversion of user queries into
 -- canonical forms.
-astToValue :: AST.Value -> Maybe Value
-astToValue (AST.ValueInt x) = pure $ ValueInt x
-astToValue (AST.ValueFloat x) = pure $ ValueFloat x
-astToValue (AST.ValueBoolean x) = pure $ ValueBoolean x
-astToValue (AST.ValueString (AST.StringValue x)) = pure $ ValueString $ String x
-astToValue (AST.ValueEnum x) = pure $ ValueEnum x
-astToValue (AST.ValueList (AST.ListValue xs)) = ValueList . List <$> traverse astToValue xs
-astToValue (AST.ValueObject (AST.ObjectValue fields)) = do
+astToValue' :: (AST.Value -> scalar) -> AST.Value -> Maybe (Value' scalar)
+astToValue' f x@(AST.ValueInt _) = pure (ValueScalar' (f x))
+astToValue' f x@(AST.ValueFloat _) = pure (ValueScalar' (f x))
+astToValue' f x@(AST.ValueBoolean _) = pure (ValueScalar' (f x))
+astToValue' f x@(AST.ValueString (AST.StringValue _)) = pure (ValueScalar' (f x))
+astToValue' f x@(AST.ValueEnum _) = pure (ValueScalar' (f x))
+astToValue' f AST.ValueNull = pure (ValueScalar' (f AST.ValueNull))
+astToValue' f x@(AST.ValueVariable _) = pure (ValueScalar' (f x))
+astToValue' f (AST.ValueList (AST.ListValue xs)) = ValueList' . List' <$> traverse (astToValue' f) xs
+astToValue' f (AST.ValueObject (AST.ObjectValue fields)) = do
   fields' <- traverse toObjectField fields
   object <- makeObject fields'
-  pure (ValueObject object)
+  pure (ValueObject' object)
   where
-    toObjectField (AST.ObjectField name value) = ObjectField name <$> astToValue value
-astToValue AST.ValueNull = pure ValueNull
-astToValue (AST.ValueVariable _) = empty
+    toObjectField (AST.ObjectField name value) = ObjectField' name <$> astToValue' f value
 
--- | A value from the AST can be converted to a literal value and back, unless it's a variable.
-prop_roundtripFromAST :: AST.Value -> Bool
-prop_roundtripFromAST ast =
-  case astToValue ast of
-    Nothing -> True
-    Just value -> ast == valueToAST value
+-- | Convert an AST value to a variable value.
+--
+-- Will fail if the AST value contains duplicate object fields, or is
+-- otherwise invalid.
+astToVariableValue :: HasCallStack => AST.Value -> Maybe VariableValue
+astToVariableValue ast = astToValue' convertScalar ast
+  where
+    convertScalar x =
+      case astToScalar x of
+        Just scalar -> scalar
+        Nothing -> panic ("Non-scalar passed to convertScalar, bug in astToValue': " <> show x)
+
+-- | Convert a value to an AST value.
+valueToAST :: Value -> AST.Value
+valueToAST = valueToAST' constToAST
+
+-- | Convert a variable value to an AST value.
+variableValueToAST :: VariableValue -> AST.Value
+variableValueToAST = valueToAST' variableToAST
 
 -- | Convert a literal value into an AST value.
 --
@@ -278,21 +418,9 @@ prop_roundtripFromAST ast =
 --
 -- This function probably isn't particularly useful, but it functions as a
 -- stop-gap until we have QuickCheck generators for the AST.
-valueToAST :: Value -> AST.Value
-valueToAST (ValueInt x) = AST.ValueInt x
-valueToAST (ValueFloat x) = AST.ValueFloat x
-valueToAST (ValueBoolean x) = AST.ValueBoolean x
-valueToAST (ValueString (String x)) = AST.ValueString (AST.StringValue x)
-valueToAST (ValueEnum x) = AST.ValueEnum x
-valueToAST (ValueList (List xs)) = AST.ValueList (AST.ListValue (map valueToAST xs))
-valueToAST (ValueObject (Object fields)) = AST.ValueObject (AST.ObjectValue (map toObjectField (OrderedMap.toList fields)))
+valueToAST' :: (scalar -> AST.Value) -> Value' scalar -> AST.Value
+valueToAST' f (ValueScalar' x) = f x
+valueToAST' f (ValueList' (List' xs)) = AST.ValueList (AST.ListValue (map (valueToAST' f) xs))
+valueToAST' f (ValueObject' (Object' fields)) = AST.ValueObject (AST.ObjectValue (map toObjectField (OrderedMap.toList fields)))
   where
-    toObjectField (name, value) = AST.ObjectField name (valueToAST value)
-valueToAST ValueNull = AST.ValueNull
-
--- | A literal value can be converted to the AST and back.
-prop_roundtripFromValue :: Value -> Bool
-prop_roundtripFromValue value =
-  case astToValue (valueToAST value) of
-    Nothing -> False
-    Just value' -> value == value'
+    toObjectField (name, value) = AST.ObjectField name (valueToAST' f value)

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -183,8 +183,8 @@ instance Arbitrary ConstScalar where
                     ]
 
 -- | Convert a constant scalar to an AST.Value
-constToAST :: ConstScalar -> AST.Value
-constToAST scalar =
+constScalarToAST :: ConstScalar -> AST.Value
+constScalarToAST scalar =
   case scalar of
     ConstInt x -> AST.ValueInt x
     ConstFloat x -> AST.ValueFloat x
@@ -196,7 +196,7 @@ constToAST scalar =
 -- | Convert a variable scalar to an AST.Value
 variableToAST :: UnresolvedVariableScalar -> AST.Value
 variableToAST (Left variable) = AST.ValueVariable variable
-variableToAST (Right constant) = constToAST constant
+variableToAST (Right constant) = constScalarToAST constant
 
 -- | Convert a value from the AST into a variable scalar, presuming it /is/ a
 -- scalar.
@@ -419,7 +419,7 @@ astToVariableValue ast = astToValue' convertScalar ast
 
 -- | Convert a value to an AST value.
 valueToAST :: Value -> AST.Value
-valueToAST = valueToAST' constToAST
+valueToAST = valueToAST' constScalarToAST
 
 -- | Convert a variable value to an AST value.
 variableValueToAST :: UnresolvedVariableValue -> AST.Value

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -110,10 +110,13 @@ genValue n
 type Value = Value' ConstScalar
 
 -- TODO: These next two definitions are quite internal. We should move this
--- mode to Internal and then re-export the bits that end-users will use.
+-- module to Internal and then re-export the bits that end-users will use.
 
--- | A GraphQL value which might contain some variables, some of which may not
--- have definitions.
+-- | A GraphQL value which might contain some variables. These variables are
+-- not yet associated with
+-- <https://facebook.github.io/graphql/#VariableDefinition variable
+-- definitions> (see also 'GraphQL.Internal.Validation.VariableDefinition'),
+-- which are provided in a different context.
 type UnresolvedVariableValue = Value' UnresolvedVariableScalar
 
 pattern ValueInt :: Int32 -> Value

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -11,7 +11,8 @@
 -- | Literal GraphQL values.
 module GraphQL.Value
   ( Value
-  , VariableValue
+  , Value'
+  , ConstScalar
   , UnresolvedVariableValue
   , pattern ValueInt
   , pattern ValueFloat
@@ -54,7 +55,7 @@ import qualified Data.Map as Map
 import Test.QuickCheck (Arbitrary(..), Gen, oneof, listOf, sized)
 
 import GraphQL.Internal.Arbitrary (arbitraryText)
-import GraphQL.Internal.AST (Name(..), Variable, VariableDefinition)
+import GraphQL.Internal.AST (Name(..), Variable)
 import qualified GraphQL.Internal.AST as AST
 import GraphQL.Internal.OrderedMap (OrderedMap)
 import qualified GraphQL.Internal.OrderedMap as OrderedMap
@@ -67,7 +68,7 @@ import qualified GraphQL.Internal.OrderedMap as OrderedMap
 --
 -- Normally, it is one of either 'ConstScalar' (to indicate that there are no
 -- variables whatsoever) or 'VariableScalar' (to indicate that there might be
--- some variables)
+-- some variables).
 data Value' scalar
   = ValueScalar' scalar
   | ValueList' (List' scalar)
@@ -112,9 +113,6 @@ type Value = Value' ConstScalar
 -- | A GraphQL value which might contain some variables, some of which may not
 -- have definitions.
 type UnresolvedVariableValue = Value' UnresolvedVariableScalar
-
--- | A GraphQL value which might contain some defined variables.
-type VariableValue = Value' VariableScalar
 
 pattern ValueInt :: Int32 -> Value
 pattern ValueInt x = ValueScalar' (ConstInt x)
@@ -164,9 +162,6 @@ instance ToJSON ConstScalar where
   toJSON (ConstString x) = toJSON x
   toJSON (ConstEnum x) = toJSON x
   toJSON ConstNull = Aeson.Null
-
--- | A value which contains no other values, and might be a variable.
-type VariableScalar = Either VariableDefinition ConstScalar
 
 -- | A value which contains no other values, and might be a variable that
 -- might lack a definition.

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -11,6 +11,7 @@
 -- | Literal GraphQL values.
 module GraphQL.Value
   ( Value
+  , VariableValue
   , pattern ValueInt
   , pattern ValueFloat
   , pattern ValueBoolean

--- a/tests/Examples/FileSystem.hs
+++ b/tests/Examples/FileSystem.hs
@@ -8,7 +8,6 @@ import GraphQL
 import GraphQL.API
 import GraphQL.Resolver (Handler, Result, (:<>)(..), buildResolver)
 import GraphQL.Value (Value)
-import GraphQL.Internal.Validation (VariableValue)
 
 import qualified System.Directory as SD
 
@@ -54,7 +53,7 @@ root = do
 example :: IO (Result Value)
 example = buildResolver @IO @Query root (query "{ root(path: \"/etc\") { entries { name } } }")
 
-query :: Text -> SelectionSet VariableValue
-query q = either panic identity $ do
-  document <- first show (compileQuery q)
-  note "Multiple operations defined" (getOperation document Nothing)
+query :: Text -> SelectionSet Value
+query q = either (panic . show) identity $ do
+  document <- compileQuery q
+  getOperation document Nothing mempty

--- a/tests/Examples/FileSystem.hs
+++ b/tests/Examples/FileSystem.hs
@@ -8,6 +8,7 @@ import GraphQL
 import GraphQL.API
 import GraphQL.Resolver (Handler, Result, (:<>)(..), buildResolver)
 import GraphQL.Value (Value)
+import qualified GraphQL.Internal.AST as AST
 
 import qualified System.Directory as SD
 
@@ -53,7 +54,7 @@ root = do
 example :: IO (Result Value)
 example = buildResolver @IO @Query root (query "{ root(path: \"/etc\") { entries { name } } }")
 
-query :: Text -> SelectionSet
+query :: Text -> SelectionSet AST.Value
 query q = either panic identity $ do
   document <- first show (compileQuery q)
   note "Multiple operations defined" (getOperation document Nothing)

--- a/tests/Examples/FileSystem.hs
+++ b/tests/Examples/FileSystem.hs
@@ -8,7 +8,7 @@ import GraphQL
 import GraphQL.API
 import GraphQL.Resolver (Handler, Result, (:<>)(..), buildResolver)
 import GraphQL.Value (Value)
-import qualified GraphQL.Internal.AST as AST
+import GraphQL.Internal.Validation (VariableValue)
 
 import qualified System.Directory as SD
 
@@ -54,7 +54,7 @@ root = do
 example :: IO (Result Value)
 example = buildResolver @IO @Query root (query "{ root(path: \"/etc\") { entries { name } } }")
 
-query :: Text -> SelectionSet AST.Value
+query :: Text -> SelectionSet VariableValue
 query q = either panic identity $ do
   document <- first show (compileQuery q)
   note "Multiple operations defined" (getOperation document Nothing)

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -7,7 +7,7 @@ import GraphQL.API
 import GraphQL (compileQuery, getOperation)
 import GraphQL.Resolver
 import GraphQL.Value (Value)
-import qualified GraphQL.Internal.AST as AST
+import GraphQL.Internal.Validation (VariableValue)
 
 -- Slightly reduced example from the spec
 type MiniCat = Object "MiniCat" '[] '[Field "name" Text, Field "meowVolume" Int32]
@@ -55,7 +55,7 @@ exampleQuery = buildResolver @IO @CatOrDog catOrDog (query "{ ... on MiniCat { n
 exampleListQuery :: IO (Result Value)
 exampleListQuery = buildResolver @IO @CatOrDogList catOrDogList  (query "{ ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } }")
 
-query :: Text -> Validation.SelectionSet AST.Value
+query :: Text -> Validation.SelectionSet VariableValue
 query q =
   let Right doc = compileQuery q
       Just x = getOperation doc Nothing

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -7,7 +7,6 @@ import GraphQL.API
 import GraphQL (compileQuery, getOperation)
 import GraphQL.Resolver
 import GraphQL.Value (Value)
-import GraphQL.Internal.Validation (VariableValue)
 
 -- Slightly reduced example from the spec
 type MiniCat = Object "MiniCat" '[] '[Field "name" Text, Field "meowVolume" Int32]
@@ -55,8 +54,8 @@ exampleQuery = buildResolver @IO @CatOrDog catOrDog (query "{ ... on MiniCat { n
 exampleListQuery :: IO (Result Value)
 exampleListQuery = buildResolver @IO @CatOrDogList catOrDogList  (query "{ ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } }")
 
-query :: Text -> Validation.SelectionSet VariableValue
+query :: Text -> Validation.SelectionSet Value
 query q =
   let Right doc = compileQuery q
-      Just x = getOperation doc Nothing
+      Right x = getOperation doc Nothing mempty
   in x

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -34,15 +34,24 @@ catOrDogList =
   , unionValue @MiniDog miniDog
   ]
 
+-- $setup
+-- >>> import qualified GraphQL.Internal.Encoder as Encode
+-- >>> import GraphQL.Value (valueToAST)
+
+
 -- | Show usage of a single unionValue
--- >>> exampleQuery
--- Result [] (ValueObject (Object {objectFields = [ObjectField (Name {getNameText = "name"}) (ValueString (String "MonadicFelix")),ObjectField (Name {getNameText = "meowVolume"}) (ValueInt 32)]}))
+--
+-- >>> (Result _ result) <- exampleQuery
+-- >>> putStrLn $ Encode.value (valueToAST result)
+-- {name:"MonadicFelix",meowVolume:32}
 exampleQuery :: IO (Result Value)
 exampleQuery = buildResolver @IO @CatOrDog catOrDog (query "{ ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } }")
 
 -- | 'unionValue' can be used in a list context
--- >>> exampleListQuery
--- Result [] (ValueList (List [ValueObject (Object {objectFields = [ObjectField (Name {getNameText = "name"}) (ValueString (String "Felix")),ObjectField (Name {getNameText = "meowVolume"}) (ValueInt 32)]}),ValueObject (Object {objectFields = [ObjectField (Name {getNameText = "name"}) (ValueString (String "Mini")),ObjectField (Name {getNameText = "meowVolume"}) (ValueInt 32)]}),ValueObject (Object {objectFields = [ObjectField (Name {getNameText = "barkVolume"}) (ValueInt 100)]})]))
+--
+-- >>> (Result _ result) <- exampleListQuery
+-- >>> putStrLn $ Encode.value (valueToAST result)
+-- [{name:"Felix",meowVolume:32},{name:"Mini",meowVolume:32},{barkVolume:100}]
 exampleListQuery :: IO (Result Value)
 exampleListQuery = buildResolver @IO @CatOrDogList catOrDogList  (query "{ ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } }")
 

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -7,6 +7,7 @@ import GraphQL.API
 import GraphQL (compileQuery, getOperation)
 import GraphQL.Resolver
 import GraphQL.Value (Value)
+import qualified GraphQL.Internal.AST as AST
 
 -- Slightly reduced example from the spec
 type MiniCat = Object "MiniCat" '[] '[Field "name" Text, Field "meowVolume" Int32]
@@ -45,7 +46,7 @@ exampleQuery = buildResolver @IO @CatOrDog catOrDog (query "{ ... on MiniCat { n
 exampleListQuery :: IO (Result Value)
 exampleListQuery = buildResolver @IO @CatOrDogList catOrDogList  (query "{ ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } }")
 
-query :: Text -> Validation.SelectionSet
+query :: Text -> Validation.SelectionSet AST.Value
 query q =
   let Right doc = compileQuery q
       Just x = getOperation doc Nothing

--- a/tests/OrderedMapTests.hs
+++ b/tests/OrderedMapTests.hs
@@ -1,0 +1,43 @@
+module OrderedMapTests (tests) where
+
+import Protolude
+
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck (Gen, arbitrary, forAll)
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
+
+import qualified Data.Map as Map
+import GraphQL.Internal.OrderedMap (OrderedMap)
+import qualified GraphQL.Internal.OrderedMap as OrderedMap
+
+
+orderedMaps :: Gen (OrderedMap Int Int)
+orderedMaps = arbitrary
+
+tests :: IO TestTree
+tests = testSpec "OrderedMap" $ do
+  describe "Integrity" $ do
+    prop "fromList . toList == id" $ do
+      forAll orderedMaps (\x -> OrderedMap.orderedMap (OrderedMap.toList x) == Just x)
+    prop "keys == Map.keys . toMap" $ do
+      forAll orderedMaps (\x -> sort (OrderedMap.keys x) == sort (Map.keys (OrderedMap.toMap x)))
+    prop "keys == map fst . Map.toList" $ do
+      forAll orderedMaps (\x -> OrderedMap.keys x == map fst (OrderedMap.toList x))
+    prop "has unique keys" $ do
+      forAll orderedMaps (\x -> let ks = OrderedMap.keys x in ks == ordNub ks)
+    prop "all keys can be looked up" $ do
+      forAll orderedMaps (\x -> let keys = OrderedMap.keys x
+                                    values = OrderedMap.values x
+                                in mapMaybe (flip OrderedMap.lookup x) keys == values)
+    it "empty is orderedMap []" $ do
+      Just (OrderedMap.empty @Int @Int) `shouldBe` OrderedMap.orderedMap []
+    prop "singleton x is orderedMap [x]" $ do
+      \x y -> Just (OrderedMap.singleton @Int @Int x y) == OrderedMap.orderedMap [(x, y)]
+    it "preserves insertion order" $ do
+      let items1 = [("foo", 2), ("bar", 1)]
+      let Just x = OrderedMap.orderedMap items1
+      OrderedMap.toList @Text @Int x `shouldBe` items1
+      let items2 = [("bar", 1), ("foo", 2)]
+      let Just y = OrderedMap.orderedMap items2
+      OrderedMap.toList @Text @Int y `shouldBe` items2

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -7,6 +7,7 @@ import Protolude
 import Test.Tasty (defaultMain, testGroup)
 
 import qualified ASTTests
+import qualified OrderedMapTests
 import qualified TypeApiTests
 import qualified TypeTests
 import qualified ValidationTests
@@ -23,6 +24,7 @@ main = do
   where
     tests =
       [ ASTTests.tests
+      , OrderedMapTests.tests
       , TypeApiTests.tests
       , TypeTests.tests
       , ValidationTests.tests

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -40,12 +40,12 @@ tHandler :: Handler TMonad T
 tHandler =
   pure $ (pure 10) :<> (\tArg -> pure tArg) :<> (pure . (*2))
 
-getQuery :: Text -> SelectionSet
+getQuery :: Text -> SelectionSet AST.Value
 getQuery query = either panic identity $ do
   validated <- first show (compileQuery query)
   note "Multiple operations found. Must specify name." (getOperation validated Nothing)
 
-runQuery :: SelectionSet -> IO (Either Text (Result Value))
+runQuery :: SelectionSet AST.Value -> IO (Either Text (Result Value))
 runQuery query = runExceptT (buildResolver @TMonad @T tHandler query)
 
 tests :: IO TestTree

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -26,7 +26,6 @@ import GraphQL.Resolver
   )
 import GraphQL.Value (Value)
 import qualified GraphQL.Internal.AST as AST
-import GraphQL.Internal.Validation (VariableValue)
 import Data.Aeson (encode)
 
 -- Test a custom error monad
@@ -41,12 +40,12 @@ tHandler :: Handler TMonad T
 tHandler =
   pure $ (pure 10) :<> (\tArg -> pure tArg) :<> (pure . (*2))
 
-getQuery :: Text -> SelectionSet VariableValue
-getQuery query = either panic identity $ do
-  validated <- first show (compileQuery query)
-  note "Multiple operations found. Must specify name." (getOperation validated Nothing)
+getQuery :: Text -> SelectionSet Value
+getQuery query = either (panic . show) identity $ do
+  validated <- compileQuery query
+  getOperation validated Nothing mempty
 
-runQuery :: SelectionSet VariableValue -> IO (Either Text (Result Value))
+runQuery :: SelectionSet Value -> IO (Either Text (Result Value))
 runQuery query = runExceptT (buildResolver @TMonad @T tHandler query)
 
 tests :: IO TestTree

--- a/tests/TypeApiTests.hs
+++ b/tests/TypeApiTests.hs
@@ -26,6 +26,7 @@ import GraphQL.Resolver
   )
 import GraphQL.Value (Value)
 import qualified GraphQL.Internal.AST as AST
+import GraphQL.Internal.Validation (VariableValue)
 import Data.Aeson (encode)
 
 -- Test a custom error monad
@@ -40,12 +41,12 @@ tHandler :: Handler TMonad T
 tHandler =
   pure $ (pure 10) :<> (\tArg -> pure tArg) :<> (pure . (*2))
 
-getQuery :: Text -> SelectionSet AST.Value
+getQuery :: Text -> SelectionSet VariableValue
 getQuery query = either panic identity $ do
   validated <- first show (compileQuery query)
   note "Multiple operations found. Must specify name." (getOperation validated Nothing)
 
-runQuery :: SelectionSet AST.Value -> IO (Either Text (Result Value))
+runQuery :: SelectionSet VariableValue -> IO (Either Text (Result Value))
 runQuery query = runExceptT (buildResolver @TMonad @T tHandler query)
 
 tests :: IO TestTree

--- a/tests/TypeTests.hs
+++ b/tests/TypeTests.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TypeOperators #-}
 module TypeTests (tests) where
 
 import Protolude hiding (Down, Enum)

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -11,10 +11,11 @@ import qualified GraphQL.Internal.AST as AST
 import GraphQL.Internal.Arbitrary (arbitraryText, arbitraryNonEmpty)
 import GraphQL.Internal.AST (unsafeMakeName)
 import GraphQL.Value
-  ( Object(..)
+  ( Object
   , ObjectField(..)
   , astToValue
   , unionObjects
+  , objectFields
   , objectFromList
   , prop_roundtripFromAST
   , prop_roundtripFromValue


### PR DESCRIPTION
This is a pretty big change. I'm sorry that it will make the review harder, but I struggled to separate it into meaningful chunks in my head.

GitHub hides `Value` and `Validation` for me, and I think that might be the best way to review it. Review the stuff that _uses_ those first, then review those two to see how it's all implemented.

The goal was to substitute variables. This meant restructuring `Value` (as discussed), and parametrising most of the types in the `Validation` module by value, to indicate whether they are AST values, valid values that might be variables that don't have definitions, valid values that might be variables that _do_ have definitions, or just concrete values.

One nice thing that falls out of the approach Validation was already taking is that we get the dynamic scoping of GraphQL rather naturally.

The "user-facing" API has been polished a little bit, and you can maybe see hints of this coming together in the examples. We're now exposing the fact that, say, `QueryDocument` is a parametrised type to end users. I'd be OK with adding a bucketload of `newtype` definitions to hide that, but would rather not abandon the type parameter approach in the implementation unless we can find something that provides the same guarantees about the state of our values (Validation is getting rather large, and I need the compiler to help me keep things straight!) and doesn't involve a tonne of duplication.

Fixes #58