### PR TITLE
Move syntax modules to Syntax sub-package

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -40,14 +40,15 @@ library
       GraphQL.API
       GraphQL.API.Enum
       GraphQL.Internal.Arbitrary
-      GraphQL.Internal.AST
-      GraphQL.Internal.Encoder
       GraphQL.Internal.Execution
+      GraphQL.Internal.Name
       GraphQL.Internal.OrderedMap
       GraphQL.Internal.Output
-      GraphQL.Internal.Parser
       GraphQL.Internal.Schema
-      GraphQL.Internal.Tokens
+      GraphQL.Internal.Syntax.AST
+      GraphQL.Internal.Syntax.Encoder
+      GraphQL.Internal.Syntax.Parser
+      GraphQL.Internal.Syntax.Tokens
       GraphQL.Internal.Validation
       GraphQL.Resolver
       GraphQL.Value

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -22,14 +22,14 @@ import Protolude
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
-import qualified GraphQL.Internal.AST as AST
 import GraphQL.Internal.Execution
   ( VariableValues
   , ExecutionError
   , substituteVariables
   )
 import qualified GraphQL.Internal.Execution as Execution
-import qualified GraphQL.Internal.Parser as Parser
+import qualified GraphQL.Internal.Syntax.AST as AST
+import qualified GraphQL.Internal.Syntax.Parser as Parser
 import GraphQL.Internal.Validation
   ( QueryDocument
   , SelectionSet

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -37,7 +37,7 @@ import Protolude hiding (Enum, TypeError)
 import GraphQL.Internal.Schema hiding (Type)
 import qualified GraphQL.Internal.Schema (Type)
 import GHC.TypeLits (Symbol, KnownSymbol, TypeError, ErrorMessage(..))
-import GraphQL.Internal.AST (NameError, nameFromSymbol)
+import GraphQL.Internal.Name (NameError, nameFromSymbol)
 import GraphQL.API.Enum (GraphQLEnum(..))
 import GHC.Generics ((:*:)(..))
 

--- a/src/GraphQL/API/Enum.hs
+++ b/src/GraphQL/API/Enum.hs
@@ -13,7 +13,7 @@ module GraphQL.API.Enum
   ) where
 
 import Protolude hiding (Enum, TypeError)
-import GraphQL.Internal.AST (Name, nameFromSymbol, NameError)
+import GraphQL.Internal.Name (Name, nameFromSymbol, NameError)
 import GraphQL.Internal.Output (GraphQLError(..))
 import GHC.Generics (D, (:+:)(..))
 import GHC.TypeLits (KnownSymbol, TypeError, ErrorMessage(..))

--- a/src/GraphQL/Internal/AST.hs
+++ b/src/GraphQL/Internal/AST.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module GraphQL.Internal.AST
-  ( Name(getNameText)
+  ( Name(unName)
   , NameError(..)
   , nameParser
   , makeName
@@ -70,10 +70,10 @@ import GraphQL.Internal.Tokens (tok)
 -- | A name in GraphQL.
 --
 -- https://facebook.github.io/graphql/#sec-Names
-newtype Name = Name { getNameText :: Text } deriving (Eq, Ord, Show)
+newtype Name = Name { unName :: Text } deriving (Eq, Ord, Show)
 
 instance Aeson.ToJSON Name where
-  toJSON = Aeson.toJSON . getNameText
+  toJSON = Aeson.toJSON . unName
 
 instance Arbitrary Name where
   arbitrary = do
@@ -100,7 +100,7 @@ newtype NameError = NameError Text deriving (Eq, Show)
 -- not match, return Nothing.
 --
 -- >>> makeName "foo"
--- Right (Name {getNameText = "foo"})
+-- Right (Name {unName = "foo"})
 -- >>> makeName "9-bar"
 -- Left (NameError "9-bar")
 makeName :: Text -> Either NameError Name
@@ -111,7 +111,7 @@ makeName name = first (const (NameError name)) (A.parseOnly nameParser name)
 -- Prefer 'makeName' to this in all cases.
 --
 -- >>> unsafeMakeName "foo"
--- Name {getNameText = "foo"}
+-- Name {unName = "foo"}
 unsafeMakeName :: HasCallStack => Text -> Name
 unsafeMakeName name =
   case makeName name of

--- a/src/GraphQL/Internal/Name.hs
+++ b/src/GraphQL/Internal/Name.hs
@@ -1,0 +1,54 @@
+-- | Representation of GraphQL names.
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module GraphQL.Internal.Name
+  ( Name(unName)
+  , NameError(..)
+  , makeName
+  , nameFromSymbol
+  -- * Unsafe functions
+  , unsafeMakeName
+  ) where
+
+import Protolude
+
+import qualified Data.Attoparsec.Text as A
+import GHC.TypeLits (Symbol, KnownSymbol, symbolVal)
+import GraphQL.Internal.Syntax.AST
+  ( Name(..)
+  , nameParser
+  )
+
+-- | An invalid name.
+newtype NameError = NameError Text deriving (Eq, Show)
+
+-- | Create a 'Name'.
+--
+-- Names must match the regex @[_A-Za-z][_0-9A-Za-z]*@. If the given text does
+-- not match, return Nothing.
+--
+-- >>> makeName "foo"
+-- Right (Name {unName = "foo"})
+-- >>> makeName "9-bar"
+-- Left (NameError "9-bar")
+makeName :: Text -> Either NameError Name
+makeName name = first (const (NameError name)) (A.parseOnly nameParser name)
+
+-- | Convert a type-level 'Symbol' into a GraphQL 'Name'.
+nameFromSymbol :: forall (n :: Symbol). KnownSymbol n => Either NameError Name
+nameFromSymbol = makeName (toS (symbolVal @n Proxy))
+
+-- | Create a 'Name', panicking if the given text is invalid.
+--
+-- Prefer 'makeName' to this in all cases.
+--
+-- >>> unsafeMakeName "foo"
+-- Name {unName = "foo"}
+unsafeMakeName :: HasCallStack => Text -> Name
+unsafeMakeName name =
+  case makeName name of
+    Left e -> panic (show e)
+    Right n -> n

--- a/src/GraphQL/Internal/Name.hs
+++ b/src/GraphQL/Internal/Name.hs
@@ -9,6 +9,8 @@ module GraphQL.Internal.Name
   , NameError(..)
   , makeName
   , nameFromSymbol
+  -- * Named things
+  , HasName(..)
   -- * Unsafe functions
   , unsafeMakeName
   ) where
@@ -52,3 +54,16 @@ unsafeMakeName name =
   case makeName name of
     Left e -> panic (show e)
     Right n -> n
+
+-- | Types that implement this have values with a single canonical name in a
+-- GraphQL schema.
+--
+-- e.g. a field @foo(bar: Int32)@ would have the name @\"foo\"@.
+--
+-- If a thing *might* have a name, or has a name that might not be valid,
+-- don't use this.
+--
+-- If a thing is aliased, then return the *original* name.
+class HasName a where
+  -- | Get the name of the object.
+  getName :: a -> Name

--- a/src/GraphQL/Internal/Output.hs
+++ b/src/GraphQL/Internal/Output.hs
@@ -5,7 +5,7 @@
 module GraphQL.Internal.Output
   ( Response(..)
   , Errors
-  , Error(..)  -- XXX: Maybe export helper functions rather than constructors.
+  , Error(..)
   , GraphQLError(..)
   , singleError
   ) where
@@ -18,8 +18,9 @@ import GraphQL.Value
   , Value
   , pattern ValueObject
   , pattern ValueNull
+  , NameError(..)
   )
-import GraphQL.Internal.AST (NameError(..), unsafeMakeName)
+import GraphQL.Internal.Name (unsafeMakeName)
 import GraphQL.Value.ToValue (ToValue(..))
 
 -- | GraphQL response.

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -38,8 +38,8 @@ module GraphQL.Internal.Schema
 
 import Protolude hiding (Type)
 
-import GraphQL.Value (Value)
-import GraphQL.Internal.AST (Name, unsafeMakeName)
+import GraphQL.Value (Name, Value)
+import GraphQL.Internal.Name (unsafeMakeName)
 
 -- | Types that implement this have values with canonical names in GraphQL.
 --

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -9,8 +9,6 @@
 -- Equivalent representation of GraphQL /values/ is in "GraphQL.Value".
 module GraphQL.Internal.Schema
   ( Type(..)
-  -- * Getting names
-  , HasName(..)
   -- * Builtin types
   , Builtin(..)
   -- * Defining new types
@@ -38,20 +36,8 @@ module GraphQL.Internal.Schema
 
 import Protolude hiding (Type)
 
-import GraphQL.Value (Name, Value)
-import GraphQL.Internal.Name (unsafeMakeName)
-
--- | Types that implement this have values with canonical names in GraphQL.
---
--- e.g. a field @foo(bar: Int32)@ would have the name @\"foo\"@.
---
--- If a thing *might* have a name, or has a name that might not be valid,
--- don't use this.
---
--- If a thing is aliased, then return the *original* name.
-class HasName a where
-  -- | Get the name of the object.
-  getName :: a -> Name
+import GraphQL.Value (Value)
+import GraphQL.Internal.Name (HasName(..), Name, unsafeMakeName)
 
 -- XXX: Use the built-in NonEmptyList in Haskell
 newtype NonEmptyList a = NonEmptyList [a] deriving (Eq, Show)

--- a/src/GraphQL/Internal/Syntax/Encoder.hs
+++ b/src/GraphQL/Internal/Syntax/Encoder.hs
@@ -1,4 +1,4 @@
-module GraphQL.Internal.Encoder
+module GraphQL.Internal.Syntax.Encoder
   ( queryDocument
   , schemaDocument
   , value
@@ -9,7 +9,7 @@ import Protolude hiding (Type, intercalate)
 import qualified Data.Aeson as Aeson
 import Data.Text (Text, cons, intercalate, pack, snoc)
 
-import qualified GraphQL.Internal.AST as AST
+import qualified GraphQL.Internal.Syntax.AST as AST
 
 -- * Document
 

--- a/src/GraphQL/Internal/Syntax/Parser.hs
+++ b/src/GraphQL/Internal/Syntax/Parser.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
-module GraphQL.Internal.Parser
+module GraphQL.Internal.Syntax.Parser
   ( queryDocument
   , schemaDocument
   , value
@@ -26,8 +26,8 @@ import Data.Attoparsec.Text
   , sepBy1
   )
 
-import qualified GraphQL.Internal.AST as AST
-import GraphQL.Internal.Tokens (tok, whiteSpace)
+import qualified GraphQL.Internal.Syntax.AST as AST
+import GraphQL.Internal.Syntax.Tokens (tok, whiteSpace)
 
 -- * Document
 

--- a/src/GraphQL/Internal/Syntax/Tokens.hs
+++ b/src/GraphQL/Internal/Syntax/Tokens.hs
@@ -1,5 +1,5 @@
 -- | Basic tokenising used by parser.
-module GraphQL.Internal.Tokens
+module GraphQL.Internal.Syntax.Tokens
   ( tok
   , whiteSpace
   ) where

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -69,10 +69,10 @@ import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as Map
 import qualified Data.Set as Set
-import qualified GraphQL.Internal.AST as AST
+import qualified GraphQL.Internal.Syntax.AST as AST
 -- Directly import things from the AST that do not need validation, so that
 -- @AST.Foo@ in a type signature implies that something hasn't been validated.
-import GraphQL.Internal.AST (Name, Alias, TypeCondition, Variable)
+import GraphQL.Internal.Syntax.AST (Name, Alias, TypeCondition, Variable)
 import GraphQL.Internal.Output (GraphQLError(..))
 import GraphQL.Internal.Schema (HasName(..))
 import GraphQL.Value

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -69,12 +69,12 @@ import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import GraphQL.Internal.Name (HasName(..), Name)
 import qualified GraphQL.Internal.Syntax.AST as AST
 -- Directly import things from the AST that do not need validation, so that
 -- @AST.Foo@ in a type signature implies that something hasn't been validated.
-import GraphQL.Internal.Syntax.AST (Name, Alias, TypeCondition, Variable)
+import GraphQL.Internal.Syntax.AST (Alias, TypeCondition, Variable)
 import GraphQL.Internal.Output (GraphQLError(..))
-import GraphQL.Internal.Schema (HasName(..))
 import GraphQL.Value
   ( Value
   , Value'

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -49,10 +49,9 @@ import GraphQL.Value
   )
 import GraphQL.Value.FromValue (FromValue(..))
 import GraphQL.Value.ToValue (ToValue(..))
-import GraphQL.Internal.Name (Name, NameError(..), makeName, nameFromSymbol)
+import GraphQL.Internal.Name (Name, NameError(..), HasName(..), makeName, nameFromSymbol)
 import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.Output (GraphQLError(..))
-import GraphQL.Internal.Schema (HasName(..))
 import GraphQL.Internal.Validation
   ( SelectionSet
   , Selection'(..)

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -26,7 +26,7 @@ module GraphQL.Value
   , valueToAST
   , astToVariableValue
   , variableValueToAST
-  , Name
+  , Name(..)
   , List
   , List'(..)
   , String(..)
@@ -294,8 +294,8 @@ unionObjects objects = Object' <$> OrderedMap.unions [obj | Object' obj <- objec
 
 instance ToJSON scalar => ToJSON (Object' scalar) where
   -- Direct encoding to preserve order of keys / values
-  toJSON (Object' xs) = toJSON (Map.fromList [(getNameText k, v) | (k, v) <- OrderedMap.toList xs])
-  toEncoding (Object' xs) = pairs (foldMap (\(k, v) -> toS (getNameText k) .= v) (OrderedMap.toList xs))
+  toJSON (Object' xs) = toJSON (Map.fromList [(unName k, v) | (k, v) <- OrderedMap.toList xs])
+  toEncoding (Object' xs) = pairs (foldMap (\(k, v) -> toS (unName k) .= v) (OrderedMap.toList xs))
 
 
 

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -26,10 +26,12 @@ module GraphQL.Value
   , valueToAST
   , astToVariableValue
   , variableValueToAST
-  , Name(..)
   , List
   , List'(..)
   , String(..)
+    -- * Names
+  , Name(..)
+  , NameError(..)
     -- * Objects
   , Object
   , Object'(..)
@@ -52,8 +54,9 @@ import qualified Data.Map as Map
 import Test.QuickCheck (Arbitrary(..), Gen, oneof, listOf, sized)
 
 import GraphQL.Internal.Arbitrary (arbitraryText)
-import GraphQL.Internal.AST (Name(..), Variable)
-import qualified GraphQL.Internal.AST as AST
+import GraphQL.Internal.Name (Name(..), NameError(..))
+import GraphQL.Internal.Syntax.AST (Variable)
+import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.OrderedMap (OrderedMap)
 import qualified GraphQL.Internal.OrderedMap as OrderedMap
 

--- a/src/GraphQL/Value/FromValue.hs
+++ b/src/GraphQL/Value/FromValue.hs
@@ -17,7 +17,7 @@ module GraphQL.Value.FromValue
   ) where
 
 import Protolude hiding (TypeError)
-import GraphQL.Internal.AST (nameFromSymbol)
+import GraphQL.Internal.Name (nameFromSymbol)
 import qualified GraphQL.Internal.OrderedMap as OM
 import GraphQL.Value
 import GraphQL.Value.ToValue (ToValue(..))

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -13,18 +13,19 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import GraphQL.Value (String(..))
-import qualified GraphQL.Internal.AST as AST
-import qualified GraphQL.Internal.Parser as Parser
-import qualified GraphQL.Internal.Encoder as Encoder
+import GraphQL.Internal.Name (Name, unsafeMakeName)
+import qualified GraphQL.Internal.Syntax.AST as AST
+import qualified GraphQL.Internal.Syntax.Parser as Parser
+import qualified GraphQL.Internal.Syntax.Encoder as Encoder
 
 kitchenSink :: Text
 kitchenSink = "query queryName($foo:ComplexType,$site:Site=MOBILE){whoever123is:node(id:[123,456]){id,... on User@defer{field2{id,alias:field1(first:10,after:$foo)@include(if:$foo){id,...frag}}}}}mutation likeStory{like(story:123)@defer{story{id}}}fragment frag on Friend{foo(size:$size,bar:$b,obj:{key:\"value\"})}\n"
 
-dog :: AST.Name
-dog = AST.unsafeMakeName "dog"
+dog :: Name
+dog = unsafeMakeName "dog"
 
-someName :: AST.Name
-someName = AST.unsafeMakeName "name"
+someName :: Name
+someName = unsafeMakeName "name"
 
 tests :: IO TestTree
 tests = testSpec "AST" $ do
@@ -61,9 +62,9 @@ tests = testSpec "AST" $ do
       it "parses ununusual objects" $ do
         let input = AST.ValueObject
                     (AST.ObjectValue
-                     [ AST.ObjectField (AST.unsafeMakeName "s")
+                     [ AST.ObjectField (unsafeMakeName "s")
                        (AST.ValueString (AST.StringValue "\224\225v^6{FPDk\DC3\a")),
-                       AST.ObjectField (AST.unsafeMakeName "Hsr") (AST.ValueInt 0)
+                       AST.ObjectField (unsafeMakeName "Hsr") (AST.ValueInt 0)
                      ])
         let output = Encoder.value input
         parseOnly Parser.value output `shouldBe` Right input
@@ -120,11 +121,11 @@ tests = testSpec "AST" $ do
                          ])
                      , AST.DefinitionOperation
                        (AST.Query
-                        (AST.Node (AST.unsafeMakeName "getName") [] []
+                        (AST.Node (unsafeMakeName "getName") [] []
                          [ AST.SelectionField
                            (AST.Field Nothing dog [] []
                             [ AST.SelectionField
-                              (AST.Field Nothing (AST.unsafeMakeName "owner") [] []
+                              (AST.Field Nothing (unsafeMakeName "owner") [] []
                                [ AST.SelectionField (AST.Field Nothing someName [] [] [])
                                ])
                             ])
@@ -144,18 +145,18 @@ tests = testSpec "AST" $ do
       let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                          (AST.Query
-                           (AST.Node (AST.unsafeMakeName "houseTrainedQuery")
+                           (AST.Node (unsafeMakeName "houseTrainedQuery")
                             [ AST.VariableDefinition
-                                (AST.Variable (AST.unsafeMakeName "atOtherHomes"))
-                                (AST.TypeNamed (AST.NamedType (AST.unsafeMakeName "Boolean")))
+                                (AST.Variable (unsafeMakeName "atOtherHomes"))
+                                (AST.TypeNamed (AST.NamedType (unsafeMakeName "Boolean")))
                                 (Just (AST.ValueBoolean True))
                             ] []
                             [ AST.SelectionField
                                 (AST.Field Nothing dog [] []
                                  [ AST.SelectionField
-                                     (AST.Field Nothing (AST.unsafeMakeName "isHousetrained")
-                                      [ AST.Argument (AST.unsafeMakeName "atOtherHomes")
-                                          (AST.ValueVariable (AST.Variable (AST.unsafeMakeName "atOtherHomes")))
+                                     (AST.Field Nothing (unsafeMakeName "isHousetrained")
+                                      [ AST.Argument (unsafeMakeName "atOtherHomes")
+                                          (AST.ValueVariable (AST.Variable (unsafeMakeName "atOtherHomes")))
                                       ] [] [])
                                  ])
                             ]))

--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -150,7 +150,7 @@ tests = testSpec "End-to-end tests" $ do
               ]
             , "errors" .=
               [ object
-                [ "message" .= ("No value provided for Name {getNameText = \"dogCommand\"}, and no default specified." :: Text)
+                [ "message" .= ("No value provided for Name {unName = \"dogCommand\"}, and no default specified." :: Text)
                 ]
               ]
             ]

--- a/tests/ExampleSchema.hs
+++ b/tests/ExampleSchema.hs
@@ -88,7 +88,7 @@ import GraphQL.API
 -- XXX: This really shouldn't be part of Resolver, since whether or not a
 -- thing has a default is part of the API / Schema definition.
 import GraphQL.Resolver (Defaultable(..))
-import GraphQL.Internal.AST (getNameText)
+import GraphQL.Value (unName)
 
 -- | A command that can be given to a 'Dog'.
 --
@@ -173,7 +173,7 @@ type Dog = Object "Dog" '[Pet]
 
 instance Defaultable DogCommand where
   -- Explicitly want no default for dogCommand
-  defaultFor (getNameText -> "dogCommand") = Nothing
+  defaultFor (unName -> "dogCommand") = Nothing
   -- DogCommand shouldn't be used elsewhere in schema, but who can say?
   defaultFor _ = Nothing
 

--- a/tests/ResolverTests.hs
+++ b/tests/ResolverTests.hs
@@ -24,7 +24,7 @@ import GraphQL.Resolver
   , ResolverError(..)
   , (:<>)(..)
   )
-import qualified GraphQL.Internal.AST as AST
+import GraphQL.Internal.Name (unsafeMakeName)
 import GraphQL.Internal.Output (singleError)
 
 -- Test a custom error monad
@@ -48,7 +48,7 @@ tests = testSpec "TypeAPI" $ do
       Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ not_a_field }")
       -- TODO: jml thinks this is a really bad error message. Real problem is
       -- that `not_a_field` was provided.
-      errs `shouldBe` singleError (ValueMissing (AST.unsafeMakeName "x"))
+      errs `shouldBe` singleError (ValueMissing (unsafeMakeName "x"))
     it "complains about missing argument" $ do
       Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ t }")
-      errs `shouldBe` singleError (ValueMissing (AST.unsafeMakeName "x"))
+      errs `shouldBe` singleError (ValueMissing (unsafeMakeName "x"))

--- a/tests/SchemaTests.hs
+++ b/tests/SchemaTests.hs
@@ -18,7 +18,7 @@ import GraphQL.API
   , getFieldDefinition
   , getInterfaceDefinition
   )
-import GraphQL.Internal.AST (unsafeMakeName)
+import GraphQL.Internal.Name (unsafeMakeName)
 import GraphQL.Internal.Schema
   ( EnumTypeDefinition(..)
   , EnumValueDefinition(..)

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -10,18 +10,19 @@ import Test.QuickCheck ((===))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
-import qualified GraphQL.Internal.AST as AST
+import GraphQL.Internal.Name (Name, unsafeMakeName)
+import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.Validation
   ( ValidationError(..)
   , findDuplicates
   , getErrors
   )
 
-me :: AST.Name
-me = AST.unsafeMakeName "me"
+me :: Name
+me = unsafeMakeName "me"
 
-someName :: AST.Name
-someName = AST.unsafeMakeName "name"
+someName :: Name
+someName = unsafeMakeName "name"
 
 tests :: IO TestTree
 tests = testSpec "Validation" $ do

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -7,9 +7,9 @@ import Test.QuickCheck (forAll)
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe, shouldSatisfy)
 
-import qualified GraphQL.Internal.AST as AST
+import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.Arbitrary (arbitraryText, arbitraryNonEmpty)
-import GraphQL.Internal.AST (unsafeMakeName)
+import GraphQL.Internal.Name (unsafeMakeName)
 import GraphQL.Value
   ( Object
   , ObjectField'(..)


### PR DESCRIPTION
Includes changes in #82, so maybe review & merge that first.

I've been meaning to do this for some time. The syntax modules are all pretty self-contained, and putting them in a subdirectory means that `ls -1 src/GraphQL/Internal` shows a more meaningful list of what we're doing.

The big exception is `Name`-related stuff, which gets used everywhere. Because it's such an important concept, I've extracted it to its own internal module, `GraphQL.Internal.Name`.
