### PR TITLE
Resolve field name before checking field arguments. Closes #81.

### DIFF
--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -8,7 +8,7 @@ module EndToEndTests (tests) where
 
 import Protolude
 
-import Data.Aeson (Value(Null), toJSON, object, (.=))
+import Data.Aeson (toJSON, object, (.=))
 import GraphQL (interpretAnonymousQuery)
 import GraphQL.API (Object, Field)
 import GraphQL.Resolver ((:<>)(..), Handler)
@@ -145,12 +145,9 @@ tests = testSpec "End-to-end tests" $ do
             [ "data" .= object
               [ "dog" .= object
                 [ "name" .= ("Mortgage" :: Text)
-                , "owner" .= Null
-                ]
-              ]
-            , "errors" .=
-              [ object
-                [ "message" .= ("No value provided for Name {unName = \"dogCommand\"}, and no default specified." :: Text)
+                , "owner" .= object
+                  [ "name" .= ("jml" :: Text)
+                  ]
                 ]
               ]
             ]

--- a/tests/ResolverTests.hs
+++ b/tests/ResolverTests.hs
@@ -48,7 +48,7 @@ tests = testSpec "TypeAPI" $ do
       Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ not_a_field }")
       -- TODO: jml thinks this is a really bad error message. Real problem is
       -- that `not_a_field` was provided.
-      errs `shouldBe` singleError (ValueMissing (unsafeMakeName "x"))
+      errs `shouldBe` singleError (FieldNotFoundError (unsafeMakeName "not_a_field"))
     it "complains about missing argument" $ do
       Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ t }")
       errs `shouldBe` singleError (ValueMissing (unsafeMakeName "x"))

--- a/tests/ResolverTests.hs
+++ b/tests/ResolverTests.hs
@@ -46,8 +46,6 @@ tests = testSpec "TypeAPI" $ do
       encode object `shouldBe` "{\"t\":12}"
     it "complains about missing field" $ do
       Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ not_a_field }")
-      -- TODO: jml thinks this is a really bad error message. Real problem is
-      -- that `not_a_field` was provided.
       errs `shouldBe` singleError (FieldNotFoundError (unsafeMakeName "not_a_field"))
     it "complains about missing argument" $ do
       Right (PartialSuccess _ errs) <- runExceptT (interpretAnonymousQuery @T tHandler "{ t }")


### PR DESCRIPTION
Before this change we tried to read field arguments even if the query
never requested the actual field itself. This is obviously wrong
because we'd never supply arguments for fields we're not requesting.

Even if all fields were optionsal we'd still waste CPU cycles.