### PR TITLE
Merge selections in a set into ordered map of fields

### DIFF
--- a/HLint.hs
+++ b/HLint.hs
@@ -3,3 +3,4 @@ import "hint" HLint.Generalise
 
 ignore "Use fmap"
 ignore "Redundant do"
+ignore "Use =<<"

--- a/graphql-wai/src/GraphQL/Wai.hs
+++ b/graphql-wai/src/GraphQL/Wai.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- | Basic WAI handlers for graphql-api
 module GraphQL.Wai
   ( toApplication
   ) where
@@ -9,6 +10,7 @@ module GraphQL.Wai
 import Protolude
 
 import GraphQL (interpretAnonymousQuery)
+import GraphQL.API (HasObjectDefinition)
 import GraphQL.Resolver (HasResolver, Handler)
 import Network.Wai (Application, queryString, responseLBS)
 import GraphQL.Value.ToValue (toValue)
@@ -23,7 +25,9 @@ import qualified Data.Aeson as Aeson
 --
 -- If you have a 'Cat' type and a corresponding 'catHandler' then you
 -- can use "toApplication @Cat catHandler".
-toApplication :: forall r. (HasResolver IO r) => Handler IO r -> Application
+toApplication
+  :: forall r. (HasResolver IO r, HasObjectDefinition r)
+  => Handler IO r -> Application
 toApplication handler = app
   where
     app req respond =

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -94,14 +94,7 @@ executeQuery
 executeQuery handler document name variables =
   case getOperation document name variables of
     Left e -> pure (ExecutionFailure (singleError e))
-    Right operation ->
-      case makeSchema @api of
-        Left err -> pure (PreExecutionFailure (toError err :| []))
-        Right allTypes ->
-          -- TODO: At this point we know that the schema is valid (at least
-          -- name-wise, which is all we check at the moment. Would be great to
-          -- pass evidence of that down to resolvers.
-          toResult <$> resolve @m @api allTypes handler (Just operation)
+    Right operation -> toResult <$> resolve @m @api handler (Just operation)
   where
     toResult (Result errors result) =
       case result of

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -22,6 +22,7 @@ import Protolude
 import Data.Attoparsec.Text (parseOnly, endOfInput)
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
+import GraphQL.API (HasObjectDefinition(..))
 import GraphQL.Internal.Execution
   ( VariableValues
   , ExecutionError
@@ -32,7 +33,7 @@ import qualified GraphQL.Internal.Syntax.AST as AST
 import qualified GraphQL.Internal.Syntax.Parser as Parser
 import GraphQL.Internal.Validation
   ( QueryDocument
-  , SelectionSet
+  , SelectionSetByType
   , ValidationErrors
   , validate
   , getSelectionSet
@@ -44,8 +45,9 @@ import GraphQL.Internal.Output
   , Response(..)
   , singleError
   )
+import GraphQL.Internal.Schema (DefinesTypes(..))
 import GraphQL.Resolver (HasResolver(..), Result(..))
-import GraphQL.Value (Name, Value, pattern ValueObject)
+import GraphQL.Value (Name, NameError, Value, pattern ValueObject)
 
 -- | Errors that can happen while processing a query document.
 data QueryError
@@ -58,6 +60,8 @@ data QueryError
   | ValidationError ValidationErrors
   -- | Validated, but failed during execution.
   | ExecutionError ExecutionError
+  -- | Error in the schema.
+  | SchemaError NameError
   -- | Got a value that wasn't an object.
   | NonObjectResult Value
   deriving (Eq, Show)
@@ -69,12 +73,14 @@ instance GraphQLError QueryError where
     "Validation errors:\n" <> mconcat ["  " <> formatError e <> "\n" | e <- NonEmpty.toList es]
   formatError (ExecutionError e) =
     "Execution error: " <> show e
+  formatError (SchemaError e) =
+    "Schema error: " <> formatError e
   formatError (NonObjectResult v) =
     "Query returned a value that is not an object: " <> show v
 
 -- | Execute a GraphQL query.
 executeQuery
-  :: forall api m. (HasResolver m api, Applicative m)
+  :: forall api m. (HasResolver m api, Applicative m, HasObjectDefinition api)
   => Handler m api -- ^ Handler for the query. This links the query to the code you've written to handle it.
   -> QueryDocument VariableValue  -- ^ A validated query document. Build one with 'compileQuery'.
   -> Maybe Name -- ^ An optional name. If 'Nothing', then executes the only operation in the query. If @Just "something"@, executes the query named @"something".
@@ -83,22 +89,32 @@ executeQuery
 executeQuery handler document name variables =
   case getOperation document name variables of
     Left e -> pure (ExecutionFailure (singleError e))
-    Right operation -> toResult <$> resolve @m @api handler operation
+    Right operation ->
+      case getAllTypes of
+        Left err -> pure (PreExecutionFailure (toError (SchemaError err) :| []))
+        Right allTypes ->
+          -- TODO: At this point we know that the schema is valid (at least
+          -- name-wise, which is all we check at the moment. Would be great to
+          -- pass evidence of that down to resolvers.
+          toResult <$> resolve @m @api allTypes handler (Just operation)
   where
     toResult (Result errors result) =
       case result of
-        -- TODO: Prevent this at compile time.
+        -- TODO: Prevent this at compile time. Particularly frustrating since
+        -- we *know* that api has an object definition.
         ValueObject object ->
           case NonEmpty.nonEmpty errors of
             Nothing -> Success object
             Just errs -> PartialSuccess object (map toError errs)
         v -> ExecutionFailure (singleError (NonObjectResult v))
 
+    getAllTypes = getDefinedTypes <$> getDefinition @api
+
 -- | Interpet a GraphQL query.
 --
 -- Compiles then executes a GraphQL query.
 interpretQuery
-  :: forall api m. (Applicative m, HasResolver m api)
+  :: forall api m. (Applicative m, HasResolver m api, HasObjectDefinition api)
   => Handler m api -- ^ Handler for the query. This links the query to the code you've written to handle it.
   -> Text -- ^ The text of a query document. Will be parsed and then executed.
   -> Maybe Name -- ^ An optional name for the operation within document to run. If 'Nothing', execute the only operation in the document. If @Just "something"@, execute the query or mutation named @"something"@.
@@ -118,7 +134,7 @@ interpretQuery handler query name variables =
 --
 -- Anonymous queries have no name and take no variables.
 interpretAnonymousQuery
-  :: forall api m. (Applicative m, HasResolver m api)
+  :: forall api m. (Applicative m, HasResolver m api, HasObjectDefinition api)
   => Handler m api -- ^ Handler for the anonymous query.
   -> Text -- ^ The text of the anonymous query. Should defined only a single, unnamed query operation.
   -> m Response -- ^ The result of running the query.
@@ -135,7 +151,7 @@ parseQuery :: Text -> Either Text AST.QueryDocument
 parseQuery query = first toS (parseOnly (Parser.queryDocument <* endOfInput) query)
 
 -- | Get an operation from a query document ready to be processed.
-getOperation :: QueryDocument VariableValue -> Maybe Name -> VariableValues -> Either QueryError (SelectionSet Value)
+getOperation :: QueryDocument VariableValue -> Maybe Name -> VariableValues -> Either QueryError (SelectionSetByType Value)
 getOperation document name vars = first ExecutionError $ do
   op <- Execution.getOperation document name
   resolved <- substituteVariables op vars

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -34,6 +34,10 @@ module GraphQL.Internal.Schema
   , NonNullType(..)
   , DefinesTypes(..)
   , doesFragmentTypeApply
+  -- * The schema
+  , Schema
+  , makeSchema
+  , lookupType
   ) where
 
 import Protolude hiding (Type)
@@ -41,6 +45,23 @@ import Protolude hiding (Type)
 import qualified Data.Map as Map
 import GraphQL.Value (Value)
 import GraphQL.Internal.Name (HasName(..), Name, unsafeMakeName)
+
+-- | An entire GraphQL schema.
+--
+-- This is very much a work in progress. Currently, the only thing we provide
+-- is a dictionary mapping type names to their definitions.
+newtype Schema = Schema (Map Name TypeDefinition) deriving (Eq, Show)
+
+-- | Create a schema from the root object.
+--
+-- This is technically an insufficient API, since not all types in a schema
+-- need to be reachable from a single root object. However, it's a start.
+makeSchema :: ObjectTypeDefinition -> Schema
+makeSchema = Schema . getDefinedTypes
+
+-- | Find the type with the given name in the schema.
+lookupType :: Schema -> Name -> Maybe TypeDefinition
+lookupType (Schema schema) name = Map.lookup name schema
 
 -- XXX: Use the built-in NonEmptyList in Haskell
 newtype NonEmptyList a = NonEmptyList [a] deriving (Eq, Show, Functor, Foldable)

--- a/src/GraphQL/Internal/Syntax/AST.hs
+++ b/src/GraphQL/Internal/Syntax/AST.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -130,10 +130,6 @@ type OperationType value = VariableDefinitions -> Directives value -> SelectionS
 
 type Operations value = Map Name (Operation value)
 
-type SelectionSet value = [Selection value]
-
-type Selection value = Selection' FragmentSpread value
-
 -- | Turn a parsed document into a known valid one.
 --
 -- The document is known to be syntactically valid, as we've got its AST.
@@ -244,6 +240,10 @@ validateArguments args = Arguments <$> mapErrors DuplicateArgument (makeMap [(na
 -- 'FragmentSpread', following this module's convention that unadorned names
 -- imply that everything is valid.
 
+type SelectionSet value = [Selection value]
+
+type Selection value = Selection' FragmentSpread value
+
 -- | A GraphQL selection.
 data Selection' (spread :: * -> *) value
   = SelectionField (Field' spread value)
@@ -259,7 +259,7 @@ data Selection' (spread :: * -> *) value
 -- TODO: At this point, we ought to know that field names are unique. As such,
 -- we should return an ordered map of Name to Fields, rather than a bland
 -- list.
-getFields :: SelectionSet value -> [Field value]
+getFields :: SelectionSet value -> [Field' FragmentSpread value]
 getFields ss = [field | SelectionField field <- ss]
 
 -- | A field in a selection set, which itself might have children which might
@@ -300,7 +300,7 @@ instance Traversable spread => Traversable (Field' spread) where
 type Field value = Field' FragmentSpread value
 
 -- | Get the value of an argument in a field.
-lookupArgument :: Field value -> Name -> Maybe value
+lookupArgument :: Field' spread value -> Name -> Maybe value
 lookupArgument (Field' _ _ (Arguments args) _ _) name = Map.lookup name args
 
 -- | Get the selection set within a field.

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -72,7 +72,12 @@ import GraphQL.Internal.Syntax.AST (Alias, TypeCondition, Variable, NamedType(..
 import GraphQL.Internal.OrderedMap (OrderedMap)
 import qualified GraphQL.Internal.OrderedMap as OrderedMap
 import GraphQL.Internal.Output (GraphQLError(..))
-import GraphQL.Internal.Schema (TypeDefinition, ObjectTypeDefinition, doesFragmentTypeApply)
+import GraphQL.Internal.Schema
+  ( TypeDefinition
+  , ObjectTypeDefinition
+  , Schema
+  , doesFragmentTypeApply
+  )
 import GraphQL.Value
   ( Value
   , Value'
@@ -122,8 +127,8 @@ type Operations value = Map Name (Operation value)
 --
 -- The document is known to be syntactically valid, as we've got its AST.
 -- Here, we confirm that it's semantically valid (modulo types).
-validate :: AST.QueryDocument -> Either (NonEmpty ValidationError) (QueryDocument VariableValue)
-validate (AST.QueryDocument defns) = runValidator $ do
+validate :: Schema -> AST.QueryDocument -> Either (NonEmpty ValidationError) (QueryDocument VariableValue)
+validate _ (AST.QueryDocument defns) = runValidator $ do
   let (operations, fragments) = splitBy splitDefns defns
   let (anonymous, named) = splitBy splitOps operations
   (frags, visitedFrags) <- resolveFragmentDefinitions =<< validateFragmentDefinitions fragments
@@ -790,9 +795,9 @@ type Validation = Validator ValidationError
 -- An empty list means no errors.
 --
 -- <https://facebook.github.io/graphql/#sec-Validation>
-getErrors :: AST.QueryDocument -> [ValidationError]
-getErrors doc =
-  case validate doc of
+getErrors :: Schema -> AST.QueryDocument -> [ValidationError]
+getErrors schema doc =
+  case validate schema doc of
     Left errors -> NonEmpty.toList errors
     Right _ -> []
 

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -227,6 +227,15 @@ validateOperation (Mutation vars directives selectionSet) = do
 type SelectionSet value = [Selection value]
 
 validateSelectionSet :: Fragments AST.Value -> [AST.Selection] -> StateT (Set Name) Validation (SelectionSet AST.Value)
+-- | Resolve all the fragments in a selection set and make sure the names,
+-- arguments, and directives are all valid.
+--
+-- Runs in 'StateT', collecting a set of names of 'FragmentDefinition' that
+-- have been used by this selection set.
+--
+-- We do this /before/ validating the values (since that's much easier once
+-- everything is in a nice structure and away from the AST), which means we
+-- can't yet evaluate directives.
 validateSelectionSet fragments selections = do
   unresolved <- lift (traverse validateSelection selections)
   resolved <- traverse (resolveSelection fragments) unresolved

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -209,7 +209,7 @@ validateOperation (Mutation vars directives selectionSet) = do
 -- | The set of arguments for a given field, directive, etc.
 --
 -- Note that the 'value' can be a variable.
-newtype Arguments value = Arguments (Map Name value) deriving (Eq, Show, Functor, Foldable, Traversable)
+newtype Arguments value = Arguments (Map Name value) deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 -- | Turn a set of arguments from the AST into a guaranteed unique set of arguments.
 --
@@ -561,7 +561,7 @@ resolveVariables definitions = traverse resolveVariableValue
 -- * Directives
 
 -- | A directive is a way of changing the run-time behaviour
-newtype Directives value = Directives (Map Name (Arguments value)) deriving (Eq, Show, Foldable, Functor, Traversable)
+newtype Directives value = Directives (Map Name (Arguments value)) deriving (Eq, Ord, Show, Foldable, Functor, Traversable)
 
 emptyDirectives :: Directives value
 emptyDirectives = Directives Map.empty

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -58,8 +58,8 @@ import GraphQL.Internal.Output (GraphQLError(..))
 import GraphQL.Internal.Schema (TypeDefinition)
 import GraphQL.Internal.Validation
   ( SelectionSetByType
-  , ExecutionField
   , SelectionSet(..)
+  , Field
   , ValidationErrors
   , getSubSelectionSet
   , getSelectionSetForType
@@ -243,7 +243,7 @@ type family FieldName (a :: Type) = (r :: Symbol) where
 
 resolveField :: forall dispatchType (m :: Type -> Type).
   (BuildFieldResolver m dispatchType, Monad m, KnownSymbol (FieldName dispatchType))
-  => AllTypes -> FieldHandler m dispatchType -> m ResolveFieldResult -> ExecutionField Value -> m ResolveFieldResult
+  => AllTypes -> FieldHandler m dispatchType -> m ResolveFieldResult -> Field Value -> m ResolveFieldResult
 resolveField allTypes handler nextHandler field =
   -- check name before
   case nameFromSymbol @(FieldName dispatchType) of
@@ -278,7 +278,7 @@ type family FieldHandler (m :: Type -> Type) (a :: Type) = (r :: Type) where
   FieldHandler m (EnumArgument (API.Argument ksF (API.Enum name t)) f) = t -> FieldHandler m f
 
 class BuildFieldResolver m fieldResolverType where
-  buildFieldResolver :: AllTypes -> FieldHandler m fieldResolverType -> ExecutionField Value -> Either ResolverError (m (Result Value))
+  buildFieldResolver :: AllTypes -> FieldHandler m fieldResolverType -> Field Value -> Either ResolverError (m (Result Value))
 
 instance forall ksG t m.
   ( KnownSymbol ksG, HasResolver m t, HasAnnotatedType t, Monad m
@@ -351,7 +351,7 @@ class RunFields m a where
   -- Individual implementations are responsible for calling 'runFields' if
   -- they haven't matched the field and there are still candidate fields
   -- within the handler.
-  runFields :: AllTypes -> RunFieldsHandler m a -> ExecutionField Value -> m ResolveFieldResult
+  runFields :: AllTypes -> RunFieldsHandler m a -> Field Value -> m ResolveFieldResult
 
 instance forall f fs m dispatchType.
          ( BuildFieldResolver m dispatchType

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -54,7 +54,7 @@ import GraphQL.Value.ToValue (ToValue(..))
 import GraphQL.Internal.Name (Name, NameError(..), HasName(..), nameFromSymbol)
 import qualified GraphQL.Internal.OrderedMap as OrderedMap
 import GraphQL.Internal.Output (GraphQLError(..))
-import GraphQL.Internal.Schema (Schema, lookupType)
+import GraphQL.Internal.Schema (Schema)
 import GraphQL.Internal.Validation
   ( SelectionSetByType
   , SelectionSet(..)
@@ -417,7 +417,7 @@ instance forall typeName interfaces fields m.
         --
         -- See <https://facebook.github.io/graphql/#sec-Field-Collection> for
         -- more details.
-        (SelectionSet ss') <- first ValidationError $ getSelectionSetForType (lookupType schema) defn selectionSet
+        (SelectionSet ss') <- first ValidationError $ getSelectionSetForType defn selectionSet
         pure ss'
 
 -- TODO(tom): we're getting to a point where it might make sense to

--- a/src/GraphQL/Value.hs
+++ b/src/GraphQL/Value.hs
@@ -41,6 +41,7 @@ module GraphQL.Value
     -- ** Constructing
   , makeObject
   , objectFromList
+  , objectFromOrderedMap
     -- ** Combining
   , unionObjects
     -- ** Querying
@@ -288,6 +289,10 @@ instance Arbitrary scalar => Arbitrary (ObjectField' scalar) where
 -- | Make an object from a list of object fields.
 makeObject :: [ObjectField' scalar] -> Maybe (Object' scalar)
 makeObject fields = objectFromList [(name, value) | ObjectField' name value <- fields]
+
+-- | Make an object from an ordered map.
+objectFromOrderedMap :: OrderedMap Name (Value' scalar) -> Object' scalar
+objectFromOrderedMap = Object'
 
 -- | Create an object from a list of (name, value) pairs.
 objectFromList :: [(Name, Value' scalar)] -> Maybe (Object' scalar)

--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -10,7 +10,7 @@ import Protolude
 
 import Data.Aeson (Value(Null), toJSON, object, (.=))
 import qualified Data.Map as Map
-import GraphQL (compileQuery, executeQuery, interpretAnonymousQuery, interpretQuery)
+import GraphQL (makeSchema, compileQuery, executeQuery, interpretAnonymousQuery, interpretQuery)
 import GraphQL.API (Object, Field)
 import GraphQL.Internal.Syntax.AST (Variable(..))
 import GraphQL.Resolver ((:<>)(..), Handler)
@@ -274,14 +274,16 @@ tests = testSpec "End-to-end tests" $ do
       toJSON (toValue response) `shouldBe` expected
     describe "Handles variables" $ do
       let root = pure (viewServerDog mortgage)
+      let Right schema = makeSchema @Dog
       let Right query =
-            compileQuery [r|query myQuery($whichCommand: DogCommand) {
-                              dog {
-                                name
-                                doesKnowCommand(dogCommand: $whichCommand)
-                              }
-                            }
-                           |]
+            compileQuery schema
+            [r|query myQuery($whichCommand: DogCommand) {
+                 dog {
+                   name
+                   doesKnowCommand(dogCommand: $whichCommand)
+                 }
+               }
+              |]
       it "Errors when no variables provided" $ do
         response <- executeQuery  @QueryRoot root query Nothing mempty
         let expected =

--- a/tests/Examples/UnionExample.hs
+++ b/tests/Examples/UnionExample.hs
@@ -10,7 +10,7 @@ import GraphQL.Resolver (Handler, (:<>)(..), unionValue)
 type MiniCat = Object "MiniCat" '[] '[Field "name" Text, Field "meowVolume" Int32]
 type MiniDog = Object "MiniDog" '[] '[Field "barkVolume" Int32]
 
-type CatOrDog = Union "CatOrDog" '[MiniCat, MiniDog]
+type CatOrDog = Object "Me" '[] '[Field "myPet" (Union "CatOrDog" '[MiniCat, MiniDog])]
 type CatOrDogList = Object "CatOrDogList" '[] '[Field "pets" (List (Union "CatOrDog" '[MiniCat, MiniDog]))]
 
 miniCat :: Text -> Handler IO MiniCat
@@ -20,7 +20,7 @@ miniDog :: Handler IO MiniDog
 miniDog = pure (pure 100)
 
 catOrDog :: Handler IO CatOrDog
-catOrDog = do
+catOrDog = pure $ do
   name <- pure "MonadicFelix" -- we can do monadic actions
   unionValue @MiniCat (miniCat name)
 
@@ -39,9 +39,9 @@ catOrDogList = pure $
 --
 -- >>> response <- exampleQuery
 -- >>> putStrLn $ encode $ toValue response
--- {"data":{"meowVolume":32,"name":"MonadicFelix"}}
+-- {"data":{"myPet":{"meowVolume":32,"name":"MonadicFelix"}}}
 exampleQuery :: IO Response
-exampleQuery = interpretAnonymousQuery @CatOrDog catOrDog "{ ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } }"
+exampleQuery = interpretAnonymousQuery @CatOrDog catOrDog "{ myPet { ... on MiniCat { name meowVolume } ... on MiniDog { barkVolume } } }"
 
 -- | 'unionValue' can be used in a list context
 --

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -12,6 +12,7 @@ import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import GraphQL.Internal.Name (Name, unsafeMakeName)
 import qualified GraphQL.Internal.Syntax.AST as AST
+import GraphQL.Internal.Schema (Schema)
 import GraphQL.Internal.Validation
   ( ValidationError(..)
   , findDuplicates
@@ -23,6 +24,11 @@ me = unsafeMakeName "me"
 
 someName :: Name
 someName = unsafeMakeName "name"
+
+-- | Schema used for these tests. Since none of them do type-level stuff, we
+-- don't need to define it.
+schema :: Schema
+schema = undefined
 
 tests :: IO TestTree
 tests = testSpec "Validation" $ do
@@ -37,7 +43,7 @@ tests = testSpec "Validation" $ do
                     )
                   )
                 ]
-      getErrors doc `shouldBe` []
+      getErrors schema doc `shouldBe` []
 
     it "Detects duplicate operation names" $ do
       let doc = AST.QueryDocument
@@ -56,7 +62,7 @@ tests = testSpec "Validation" $ do
                     )
                   )
                 ]
-      getErrors doc `shouldBe` [DuplicateOperation me]
+      getErrors schema doc `shouldBe` [DuplicateOperation me]
 
     it "Detects duplicate anonymous operations" $ do
       let doc = AST.QueryDocument
@@ -71,7 +77,7 @@ tests = testSpec "Validation" $ do
                     ]
                   )
                 ]
-      getErrors doc `shouldBe` [MixedAnonymousOperations 2 []]
+      getErrors schema doc `shouldBe` [MixedAnonymousOperations 2 []]
 
   describe "findDuplicates" $ do
     prop "returns empty on unique lists" $ do


### PR DESCRIPTION
Fixes #59 

This makes the job of the resolver much simpler. It doesn't have to worry about inline fragments or whatever, it only deals with ordered maps of fields. 

Unfortunately, it also makes the job of the validator more complex. Recursing through the whole query to merge fields is a bit involved. Defining some generic operations on `OrderedMap` made this much easier to think about.

This PR also introduces the notion of types into the validator. We need to know the type of the object we're building a selection set for, and we need to know the definitions of the type conditions. This (to me) means building and providing a value that represents the whole schema, and making sure each resolver has it. This in turn means passing a new value, `allTypes` down through each resolver. I think this is actually a perfect use case for `ReaderT`, and would be happy to change it.

It also means changing the top-level methods to only accept GraphQL Objects. This is fine, because that's all their allowed to take: https://facebook.github.io/graphql/#sec-Initial-types

Something that naturally arises from this work is that the difference between leafs and non-leafs becomes really obvious. We talked in person about different approaches, and for this PR I settled on changing the type of resolver to take `Maybe (SelectionSet Value)`, where `Nothing` indicates a leaf query.

Testing is pretty shallow. I added one end-to-end test that shows off what this can do, but it's kind of limited. Some of the algorithmic & traversal code could probably do with property tests. Let me know which bits you trust least.

Some things on which I'd particularly like input:

- The name of `ExecutionField` (and names of new functions & types in general)
- Whether or not to use `ReaderT`
- Ways to reduce the implementation complexity of `groupByResponseKey`
