### PR TITLE
Correctly propagate Maybe handlers. Closes #102 and #119.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,19 @@ graphql-api changelog
 =====================
 
 $next (yyyy-mm-dd)
-==================
+=================
+
+
+v0.2.0 (2017-10-12)
+===================
 
 * Make ``Name`` an overloaded string that panics if an invalid name is
   provided.
+* Correctly descend into the type parameter of a ``Maybe``. See https://github.com/jml/graphql-api/issues/119.
+  This is a backwards-incompatible change.
+
+  A common update would be having to ``fmap pure callback`` instead of just ``callback``
+  for ``Maybe`` handlers.
 
 
 v0.1.0 (2017-01-30)
@@ -21,5 +30,3 @@ v0.1.0 (2017-01-29)
 ===================
 
 Initial release, support basic handling of GraphQL queries.
-
-

--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -61,7 +61,7 @@ isHouseTrained dog (Just True) = houseTrainedElsewhere dog
 viewServerDog :: ServerDog -> Handler IO Dog
 viewServerDog dog@(ServerDog{..}) = pure $
   pure name :<>
-  pure nickname :<>
+  pure (fmap pure nickname) :<>
   pure barkVolume :<>
   pure . doesKnowCommand dog :<>
   pure . isHouseTrained dog :<>
@@ -326,4 +326,3 @@ tests = testSpec "End-to-end tests" $ do
                 ]
               ]
         toJSON (toValue response) `shouldBe` expected
-


### PR DESCRIPTION
I'm not happy with this solution because of the extra monad level
introduced.

    pure (Just (pure value))

is not a good way to return a Maybe. Not sure how to fix better ATM.