### PR TITLE
Update to protolude 0.2

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -26,12 +26,13 @@ library
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
       base >= 4.9 && < 5
-    , protolude
+    , protolude >= 0.2
     , exceptions
     , transformers
     , attoparsec
     , aeson
     , containers
+    , ghc-prim
     , scientific
     , QuickCheck
     , text
@@ -65,7 +66,7 @@ test-suite graphql-api-doctests
   ghc-options: -Wall -fno-warn-redundant-constraints -threaded
   build-depends:
       base >= 4.9 && < 5
-    , protolude
+    , protolude >= 0.2
     , exceptions
     , transformers
     , attoparsec
@@ -94,7 +95,7 @@ test-suite graphql-api-tests
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
       base >= 4.9 && < 5
-    , protolude
+    , protolude >= 0.2
     , exceptions
     , transformers
     , attoparsec
@@ -131,7 +132,7 @@ benchmark criterion
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
       base >= 4.9 && < 5
-    , protolude
+    , protolude >= 0.2
     , exceptions
     , transformers
     , attoparsec

--- a/package.yaml
+++ b/package.yaml
@@ -18,7 +18,7 @@ default-extensions:
 
 dependencies:
   - base >= 4.9 && < 5
-  - protolude
+  - protolude >= 0.2
   - exceptions
   - transformers
   - attoparsec
@@ -28,6 +28,7 @@ library:
   dependencies:
     - aeson
     - containers
+    - ghc-prim
     - scientific
     - QuickCheck
     - text

--- a/src/GraphQL/API.hs
+++ b/src/GraphQL/API.hs
@@ -40,6 +40,7 @@ import GHC.TypeLits (Symbol, KnownSymbol, TypeError, ErrorMessage(..))
 import GraphQL.Internal.Name (NameError, nameFromSymbol)
 import GraphQL.API.Enum (GraphQLEnum(..))
 import GHC.Generics ((:*:)(..))
+import GHC.Types (Type)
 
 
 -- $setup

--- a/src/GraphQL/API/Enum.hs
+++ b/src/GraphQL/API/Enum.hs
@@ -17,6 +17,7 @@ import GraphQL.Internal.Name (Name, nameFromSymbol, NameError)
 import GraphQL.Internal.Output (GraphQLError(..))
 import GHC.Generics (D, (:+:)(..))
 import GHC.TypeLits (KnownSymbol, TypeError, ErrorMessage(..))
+import GHC.Types (Type)
 
 invalidEnumName :: forall t. NameError -> Either Text t
 invalidEnumName x = Left ("In Enum: " <> formatError x)

--- a/src/GraphQL/Internal/Execution.hs
+++ b/src/GraphQL/Internal/Execution.hs
@@ -14,7 +14,7 @@ module GraphQL.Internal.Execution
   , substituteVariables
   ) where
 
-import Protolude hiding (Type)
+import Protolude
 
 import qualified Data.Map as Map
 import GraphQL.Value

--- a/src/GraphQL/Internal/Schema.hs
+++ b/src/GraphQL/Internal/Schema.hs
@@ -40,7 +40,7 @@ module GraphQL.Internal.Schema
   , lookupType
   ) where
 
-import Protolude hiding (Type)
+import Protolude
 
 import qualified Data.Map as Map
 import GraphQL.Value (Value)

--- a/src/GraphQL/Internal/Syntax/AST.hs
+++ b/src/GraphQL/Internal/Syntax/AST.hs
@@ -52,7 +52,7 @@ module GraphQL.Internal.Syntax.AST
   , TypeExtensionDefinition(..)
   ) where
 
-import Protolude hiding (Type)
+import Protolude
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Attoparsec.Text as A

--- a/src/GraphQL/Internal/Syntax/Encoder.hs
+++ b/src/GraphQL/Internal/Syntax/Encoder.hs
@@ -4,7 +4,7 @@ module GraphQL.Internal.Syntax.Encoder
   , value
   ) where
 
-import Protolude hiding (Type, intercalate)
+import Protolude hiding (intercalate)
 
 import qualified Data.Aeson as Aeson
 import Data.Text (Text, cons, intercalate, pack, snoc)

--- a/src/GraphQL/Internal/Syntax/Parser.hs
+++ b/src/GraphQL/Internal/Syntax/Parser.hs
@@ -5,7 +5,7 @@ module GraphQL.Internal.Syntax.Parser
   , value
   ) where
 
-import Protolude hiding (Type, takeWhile)
+import Protolude hiding (option, takeWhile)
 
 import Control.Applicative ((<|>), empty, many, optional)
 import Control.Monad (fail)

--- a/src/GraphQL/Internal/Validation.hs
+++ b/src/GraphQL/Internal/Validation.hs
@@ -58,11 +58,12 @@ module GraphQL.Internal.Validation
   , findDuplicates
   ) where
 
-import Protolude
+import Protolude hiding ((<>))
 
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as Map
+import Data.Semigroup ((<>))
 import qualified Data.Set as Set
 import GraphQL.Internal.Name (HasName(..), Name)
 import qualified GraphQL.Internal.Syntax.AST as AST

--- a/src/GraphQL/Resolver.hs
+++ b/src/GraphQL/Resolver.hs
@@ -35,6 +35,7 @@ import Protolude hiding (Enum, TypeError)
 import qualified Data.Text as Text
 import qualified Data.List.NonEmpty as NonEmpty
 import GHC.TypeLits (KnownSymbol, TypeError, ErrorMessage(..), Symbol, symbolVal)
+import GHC.Types (Type)
 import qualified GHC.Exts (Any)
 import Unsafe.Coerce (unsafeCoerce)
 

--- a/src/GraphQL/Value/FromValue.hs
+++ b/src/GraphQL/Value/FromValue.hs
@@ -25,6 +25,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics ((:*:)(..))
 import GHC.TypeLits (KnownSymbol, TypeError, ErrorMessage(..))
+import GHC.Types (Type)
 
 -- * FromValue
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,3 +4,5 @@ packages:
   - "."
   - "./docs/source/tutorial"
   - "./graphql-wai"
+
+extra-deps: [protolude-0.2]


### PR DESCRIPTION
Hi,
this should update graphql-api to compile with protolude 0.2 on both GHC 8.0.2 and 8.2.1.