### PR TITLE
Create a Request object and an interpretRequest path

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.17.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -36,6 +36,8 @@ library
     , scientific
     , QuickCheck
     , text
+    , vector
+    , unordered-containers
   exposed-modules:
       GraphQL
       GraphQL.API

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,8 @@ library:
     - scientific
     - QuickCheck
     - text
+    - vector
+    - unordered-containers
 
 tests:
   graphql-api-tests:

--- a/src/GraphQL.hs
+++ b/src/GraphQL.hs
@@ -10,6 +10,7 @@ module GraphQL
   (
     -- * Running queries
     interpretQuery
+  , interpretRequest
   , interpretAnonymousQuery
   , Response(..)
     -- * Preparing queries then running them
@@ -32,6 +33,7 @@ import GraphQL.Internal.Execution
   ( VariableValues
   , ExecutionError
   , substituteVariables
+  , Request(..)
   )
 import qualified GraphQL.Internal.Execution as Execution
 import qualified GraphQL.Internal.Syntax.AST as AST
@@ -124,6 +126,15 @@ interpretQuery handler query name variables =
   case makeSchema @api >>= flip compileQuery query of
     Left err -> pure (PreExecutionFailure (toError err :| []))
     Right document -> executeQuery @api @m handler document name variables
+
+-- | Interpret a GraphQL query, given a packaged request.
+interpretRequest
+  :: forall api m. (Applicative m, HasResolver m api, HasObjectDefinition api)
+  => Handler m api -- ^ Handler for the query. This links the query to the code you've written to handle it.
+  -> Request -- ^ The query and its input values.
+  -> m Response -- ^ The outcome of running the query.
+interpretRequest handler (Request query name variables) =
+  interpretQuery @api @m handler query name variables
 
 -- | Interpret an anonymous GraphQL query.
 --

--- a/src/GraphQL/Internal/Syntax/AST.hs
+++ b/src/GraphQL/Internal/Syntax/AST.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -104,6 +105,12 @@ instance IsString Name where
 instance Aeson.ToJSON Name where
   toJSON = Aeson.toJSON . unName
 
+instance Aeson.FromJSON Name where
+  parseJSON = Aeson.withText "Name" $ \v ->
+    case makeName v of
+      Left _ -> mempty
+      Right name -> return name
+
 instance Arbitrary Name where
   arbitrary = do
     initial <- elements alpha
@@ -153,7 +160,11 @@ getNodeName (Node name _ _ _) = name
 data VariableDefinition = VariableDefinition Variable Type (Maybe DefaultValue)
                           deriving (Eq,Show)
 
-newtype Variable = Variable Name deriving (Eq, Ord, Show)
+newtype Variable = Variable Name deriving (Eq, Ord, Show, Aeson.FromJSON,
+                                           Aeson.ToJSON)
+
+instance Aeson.FromJSONKey Variable
+instance Aeson.ToJSONKey Variable
 
 instance Arbitrary Variable where
   arbitrary = Variable <$> arbitrary

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -5,6 +5,7 @@ module ASTTests (tests) where
 
 import Protolude
 
+import Data.Aeson (decode, encode)
 import Data.Attoparsec.Text (parseOnly)
 import Text.RawString.QQ (r)
 import Test.Hspec.QuickCheck (prop)
@@ -29,6 +30,9 @@ someName = "name"
 
 tests :: IO TestTree
 tests = testSpec "AST" $ do
+  describe "Name" $ do
+    prop "round trips valid names through JSON" $ do
+      \x -> decode (encode (x :: Name)) == Just x
   describe "Parser and encoder" $ do
     it "roundtrips on minified documents" $ do
       let actual = Encoder.queryDocument <$> parseOnly Parser.queryDocument kitchenSink

--- a/tests/EndToEndTests.hs
+++ b/tests/EndToEndTests.hs
@@ -8,9 +8,9 @@ module EndToEndTests (tests) where
 
 import Protolude
 
-import Data.Aeson (Value(Null), toJSON, object, (.=))
+import Data.Aeson (Value(Null), toJSON, object, (.=), decode, encode)
 import qualified Data.Map as Map
-import GraphQL (makeSchema, compileQuery, executeQuery, interpretAnonymousQuery, interpretQuery)
+import GraphQL (makeSchema, compileQuery, executeQuery, interpretAnonymousQuery, interpretQuery, interpretRequest)
 import GraphQL.API (Object, Field)
 import GraphQL.Internal.Syntax.AST (Variable(..))
 import GraphQL.Resolver ((:<>)(..), Handler)
@@ -326,3 +326,10 @@ tests = testSpec "End-to-end tests" $ do
                 ]
               ]
         toJSON (toValue response) `shouldBe` expected
+  describe "interpretRequest" $ do
+    it "performs a query" $ do
+      let root = pure (viewServerDog mortgage)
+      let Just request = decode [r|{"query": "{ dog { name } }"}|]
+      response <- interpretRequest @QueryRoot root request
+      let expected = "{\"data\":{\"dog\":{\"name\":\"Mortgage\"}}}"
+      encode response `shouldBe` expected

--- a/tests/ValueTests.hs
+++ b/tests/ValueTests.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE PatternSynonyms #-}
 module ValueTests (tests) where
 
 import Protolude
 
+import Data.Aeson (decode)
 import Test.Hspec.QuickCheck (prop)
 import Test.QuickCheck (forAll)
 import Test.Tasty (TestTree)
@@ -16,6 +18,13 @@ import GraphQL.Value
   , unionObjects
   , objectFields
   , objectFromList
+  , String(..)
+  , pattern ValueFloat
+  , pattern ValueBoolean
+  , pattern ValueString
+  , pattern ValueList
+  , pattern ValueNull
+  , List'(..)
   )
 import GraphQL.Value.FromValue (prop_roundtripValue)
 import GraphQL.Value.ToValue (toValue)
@@ -23,6 +32,21 @@ import GraphQL.Value.ToValue (toValue)
 
 tests :: IO TestTree
 tests = testSpec "Value" $ do
+  describe "FromJSON instance" $ do
+    it "reads a string" $ do
+      decode "\"hi\"" `shouldBe` Just (ValueString (String "hi"))
+    it "reads a numeric string as a string" $ do
+      decode "\"2\"" `shouldBe` Just (ValueString (String "2"))
+    it "reads a number as a float" $ do
+      decode "2" `shouldBe` Just (ValueFloat 2)
+    it "reads a boolean" $ do
+      decode "true" `shouldBe` Just (ValueBoolean True)
+    it "reads null" $ do
+      decode "null" `shouldBe` Just (ValueNull)
+    it "reads a list" $ do
+      decode "[1]" `shouldBe` Just (ValueList $ List' [ValueFloat 1])
+    it "reads an object" $ do
+      decode "{\"a\": \"b\"}" `shouldBe` objectFromList [("a", ValueString (String "b"))]
   describe "unionObject" $ do
     it "returns empty on empty list" $ do
       unionObjects [] `shouldBe` (objectFromList [] :: Maybe Object)


### PR DESCRIPTION
There is a mostly-standard [JSON request format](http://graphql.org/learn/serving-over-http/#post-request) that's pretty widely support across GraphQL implementations, even if not part of the spec _per se_.  This PR adds a `Request` type that mirrors that format, and a top-level `interpretRequest` entry point to run it.

The real goal of this is to allow a Servant path like

```haskell
type GraphQLAPI = "graphql"
                  :> ReqBody '[JSON] GraphQL.Request
                  :> Post '[JSON] GraphQL.Response

graphQLServer :: Server GraphQLAPI
graphQLServer = liftIO . runRequest
```

The one big caveat in this PR is that you can't 100% deserialize `Value` objects without knowing their type context.  This assumes that JSON strings are always GraphQL strings (they could also be enums or schema-specific scalar types) and that JSON numbers are always GraphQL floats (they could also be integers and that's probably the common case).