### PR TITLE
Update cabal information on hackage. Closes #107.

### DIFF
--- a/graphql-api.cabal
+++ b/graphql-api.cabal
@@ -1,15 +1,19 @@
--- This file has been generated from package.yaml by hpack version 0.17.0.
+-- This file has been generated from package.yaml by hpack version 0.20.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 6aa09d512e2d1e86eeb059e1273005913985418db5c8f94b7361af87744e6bae
 
 name:           graphql-api
 version:        0.2.0
-synopsis:       Sketch of GraphQL stuff
+synopsis:       GraphQL API
 description:    Please see README.md
 category:       Web
+stability:      unstable
 homepage:       https://github.com/jml/graphql-api#readme
 bug-reports:    https://github.com/jml/graphql-api/issues
-maintainer:     Jonathan M. Lange <jml@mumak.net>
+author:         Jonathan M. Lange
+maintainer:     Jonathan M. Lange <jml@mumak.net>, Tom Hunger <tehunger@gmail.com>
 license:        Apache
 license-file:   LICENSE.Apache-2.0
 build-type:     Simple
@@ -25,17 +29,17 @@ library
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
-      base >= 4.9 && < 5
-    , protolude >= 0.2
-    , exceptions
-    , transformers
-    , attoparsec
+      QuickCheck
     , aeson
+    , attoparsec
+    , base >=4.9 && <5
     , containers
+    , exceptions
     , ghc-prim
+    , protolude >=0.2
     , scientific
-    , QuickCheck
     , text
+    , transformers
   exposed-modules:
       GraphQL
       GraphQL.API
@@ -55,6 +59,8 @@ library
       GraphQL.Value
       GraphQL.Value.FromValue
       GraphQL.Value.ToValue
+  other-modules:
+      Paths_graphql_api
   default-language: Haskell2010
 
 test-suite graphql-api-doctests
@@ -65,12 +71,12 @@ test-suite graphql-api-doctests
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints -threaded
   build-depends:
-      base >= 4.9 && < 5
-    , protolude >= 0.2
-    , exceptions
-    , transformers
-    , attoparsec
+      attoparsec
+    , base >=4.9 && <5
     , doctest
+    , exceptions
+    , protolude >=0.2
+    , transformers
   other-modules:
       ASTTests
       EndToEndTests
@@ -84,6 +90,7 @@ test-suite graphql-api-doctests
       Spec
       ValidationTests
       ValueTests
+      Paths_graphql_api
   default-language: Haskell2010
 
 test-suite graphql-api-tests
@@ -94,20 +101,20 @@ test-suite graphql-api-tests
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
-      base >= 4.9 && < 5
-    , protolude >= 0.2
-    , exceptions
-    , transformers
-    , attoparsec
+      QuickCheck
     , aeson
+    , attoparsec
+    , base >=4.9 && <5
     , containers
+    , directory
+    , exceptions
     , graphql-api
     , hspec
-    , QuickCheck
+    , protolude >=0.2
     , raw-strings-qq
     , tasty
     , tasty-hspec
-    , directory
+    , transformers
   other-modules:
       ASTTests
       Doctests
@@ -121,6 +128,7 @@ test-suite graphql-api-tests
       SchemaTests
       ValidationTests
       ValueTests
+      Paths_graphql_api
   default-language: Haskell2010
 
 benchmark criterion
@@ -131,13 +139,14 @@ benchmark criterion
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints
   build-depends:
-      base >= 4.9 && < 5
-    , protolude >= 0.2
-    , exceptions
-    , transformers
-    , attoparsec
+      attoparsec
+    , base >=4.9 && <5
     , criterion
+    , exceptions
     , graphql-api
+    , protolude >=0.2
+    , transformers
   other-modules:
       Validation
+      Paths_graphql_api
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,12 +1,14 @@
 name: graphql-api
 version: 0.2.0
-synopsis: Sketch of GraphQL stuff
+synopsis: GraphQL API
 description: Please see README.md
-maintainer: Jonathan M. Lange <jml@mumak.net>
+author: Jonathan M. Lange
+maintainer: Jonathan M. Lange <jml@mumak.net>, Tom Hunger <tehunger@gmail.com>
 license: Apache
 license-file: LICENSE.Apache-2.0
 github: jml/graphql-api
 category: Web
+stability: unstable
 
 # NB the "redundant constraints" warning is a GHC bug: https://ghc.haskell.org/trac/ghc/ticket/11099
 ghc-options: -Wall -fno-warn-redundant-constraints


### PR DESCRIPTION
Also took the liberty to change the synopsis field. It lacked specificity.

Edited `package.yaml` then called `hpack`. Apologies for the meaningless churn in `graphql-api.cabal`.