### PR TITLE
Add tests for anonymous queries w|w/o variables

### DIFF
--- a/docs/source/tutorial/tutorial.cabal
+++ b/docs/source/tutorial/tutorial.cabal
@@ -1,6 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.20.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: b3da6c729f0fa19c9ad82cb7e45f616850463bcc1654b9cd4797e34f6685ebd8
 
 name:          tutorial
 version:       0.0.1
@@ -18,11 +20,11 @@ library
   other-modules:
       Paths_tutorial
   build-depends:
-      base >= 4.9 && < 5
-    , protolude
+      aeson
+    , base >=4.9 && <5
     , graphql-api
+    , markdown-unlit >=0.4
+    , protolude
     , random
-    , markdown-unlit >= 0.4
-    , aeson
   default-language: Haskell2010
   ghc-options: -Wall -pgmL markdown-unlit

--- a/graphql-wai/graphql-wai.cabal
+++ b/graphql-wai/graphql-wai.cabal
@@ -1,6 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.20.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 12d030d800c1c036c89a9464dd8de8b05f9f6dc28e0faae9d2b105b2b120460e
 
 name:           graphql-wai
 version:        0.1.0
@@ -22,15 +24,17 @@ library
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints -Werror
   build-depends:
-      base >= 4.9 && < 5
-    , protolude
+      aeson
+    , base >=4.9 && <5
     , exceptions
-    , wai
-    , http-types
     , graphql-api
-    , aeson
+    , http-types
+    , protolude
+    , wai
   exposed-modules:
       GraphQL.Wai
+  other-modules:
+      Paths_graphql_wai
   default-language: Haskell2010
 
 test-suite wai-tests
@@ -41,13 +45,15 @@ test-suite wai-tests
   default-extensions: NoImplicitPrelude OverloadedStrings RecordWildCards TypeApplications
   ghc-options: -Wall -fno-warn-redundant-constraints -Werror
   build-depends:
-      base >= 4.9 && < 5
-    , protolude
+      aeson
+    , base >=4.9 && <5
     , exceptions
-    , wai
-    , http-types
     , graphql-api
-    , aeson
-    , wai-extra
     , graphql-wai
+    , http-types
+    , protolude
+    , wai
+    , wai-extra
+  other-modules:
+      Paths_graphql_wai
   default-language: Haskell2010

--- a/src/GraphQL/Internal/Execution.hs
+++ b/src/GraphQL/Internal/Execution.hs
@@ -51,7 +51,7 @@ import GraphQL.Internal.Validation
 --     * Return {operation}.
 getOperation :: QueryDocument value -> Maybe Name -> Either ExecutionError (Operation value)
 getOperation (LoneAnonymousOperation op) Nothing = pure op
-getOperation (MultipleOperations ops) (Just name) = note (NoSuchOperation name) (Map.lookup name ops)
+getOperation (MultipleOperations ops) (Just name) = note (NoSuchOperation name) (Map.lookup (pure name) ops)
 getOperation (MultipleOperations ops) Nothing =
   case toList ops of
     [op] -> pure op

--- a/src/GraphQL/Internal/Name.hs
+++ b/src/GraphQL/Internal/Name.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module GraphQL.Internal.Name
   ( Name(unName, Name)
+  , mempty
   , NameError(..)
   , makeName
   , nameFromSymbol

--- a/src/GraphQL/Internal/Name.hs
+++ b/src/GraphQL/Internal/Name.hs
@@ -25,7 +25,6 @@ import Data.Text as T (Text)
 import qualified Data.Attoparsec.Text as A
 import Test.QuickCheck (Arbitrary(..), elements, listOf)
 import Data.String (IsString(..))
-import Data.Text as T (Text, append, empty)
 
 import GraphQL.Internal.Syntax.Tokens (tok)
 
@@ -36,14 +35,6 @@ import GraphQL.Internal.Syntax.Tokens (tok)
 -- https://facebook.github.io/graphql/#sec-Names
 newtype Name = Name { unName :: T.Text } deriving (Eq, Ord, Show)
 
--- | Allow Name to be parsed with `optempty`
---
--- Example: node = AST.Node <$> optempty nameParser
--- I.e. If nameParser fails, the Name field of AST.Node is set
--- mempty rather than propagating a failure. 
-instance Monoid Name where
-    mempty  = Name T.empty
-    mappend (Name a1) (Name a2) = Name (T.append a1 a2)
 
 -- | Create a 'Name', panicking if the given text is invalid.
 --

--- a/src/GraphQL/Internal/Name.hs
+++ b/src/GraphQL/Internal/Name.hs
@@ -36,19 +36,14 @@ import GraphQL.Internal.Syntax.Tokens (tok)
 -- https://facebook.github.io/graphql/#sec-Names
 newtype Name = Name { unName :: T.Text } deriving (Eq, Ord, Show)
 
+-- | Allow Name to be parsed with `optempty`
+--
+-- Example: node = AST.Node <$> optempty nameParser
+-- I.e. If nameParser fails, the Name field of AST.Node is set
+-- mempty rather than propagating a failure. 
 instance Monoid Name where
     mempty  = Name T.empty
---    mappend (Name {a}) mempty = Name {a}
---    mappend mempty (Name {b}) = Name {b}
     mappend (Name a1) (Name a2) = Name (T.append a1 a2)
---    mappend = append
---    mconcat = concat
-
---newtype Any = Any { getAny :: Bool }
-
---instance Monoid Any where
---    mempty = Any False
---    (Any b1) `mappend` (Any b2) = Any (b1 || b2)
 
 -- | Create a 'Name', panicking if the given text is invalid.
 --

--- a/src/GraphQL/Internal/Name.hs
+++ b/src/GraphQL/Internal/Name.hs
@@ -25,6 +25,7 @@ import Data.Text as T (Text)
 import qualified Data.Attoparsec.Text as A
 import Test.QuickCheck (Arbitrary(..), elements, listOf)
 import Data.String (IsString(..))
+import Data.Text as T (Text, append, empty)
 
 import GraphQL.Internal.Syntax.Tokens (tok)
 
@@ -34,6 +35,20 @@ import GraphQL.Internal.Syntax.Tokens (tok)
 --
 -- https://facebook.github.io/graphql/#sec-Names
 newtype Name = Name { unName :: T.Text } deriving (Eq, Ord, Show)
+
+instance Monoid Name where
+    mempty  = Name T.empty
+--    mappend (Name {a}) mempty = Name {a}
+--    mappend mempty (Name {b}) = Name {b}
+    mappend (Name a1) (Name a2) = Name (T.append a1 a2)
+--    mappend = append
+--    mconcat = concat
+
+--newtype Any = Any { getAny :: Bool }
+
+--instance Monoid Any where
+--    mempty = Any False
+--    (Any b1) `mappend` (Any b2) = Any (b1 || b2)
 
 -- | Create a 'Name', panicking if the given text is invalid.
 --

--- a/src/GraphQL/Internal/Name.hs
+++ b/src/GraphQL/Internal/Name.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module GraphQL.Internal.Name
   ( Name(unName, Name)
-  , mempty
   , NameError(..)
   , makeName
   , nameFromSymbol

--- a/src/GraphQL/Internal/Syntax/AST.hs
+++ b/src/GraphQL/Internal/Syntax/AST.hs
@@ -49,10 +49,10 @@ module GraphQL.Internal.Syntax.AST
 import Protolude
 
 --import Data.String (IsString(..))
-import Test.QuickCheck (Arbitrary(..), elements, listOf, oneof)
+import Test.QuickCheck (Arbitrary(..), listOf, oneof)
 
 import GraphQL.Internal.Arbitrary (arbitraryText)
-import GraphQL.Internal.Name (HasName(getName), Name(unName, Name), unsafeMakeName)
+import GraphQL.Internal.Name (Name)
 
 -- * Documents
 
@@ -76,11 +76,12 @@ data OperationDefinition
   | AnonymousQuery SelectionSet
   deriving (Eq,Show)
 
-data Node = Node Name [VariableDefinition] [Directive] SelectionSet
+data Node = Node (Maybe Name) [VariableDefinition] [Directive] SelectionSet
             deriving (Eq,Show)
 
-instance HasName Node where
-  getName (Node name _ _ _) = name
+--
+getNodeName :: Node -> Maybe Name
+getNodeName (Node maybeName _ _ _) = maybeName
 
 data VariableDefinition = VariableDefinition Variable Type (Maybe DefaultValue)
                           deriving (Eq,Show)

--- a/src/GraphQL/Internal/Syntax/Encoder.hs
+++ b/src/GraphQL/Internal/Syntax/Encoder.hs
@@ -30,9 +30,13 @@ operationDefinition (AST.Mutation n) = "mutation " <> node n
 operationDefinition (AST.AnonymousQuery ss) = selectionSet ss
 
 node :: AST.Node -> Text
-node (AST.Node name vds ds ss) =
+node (AST.Node (Just name) vds ds ss) =
      unName name
   <> optempty variableDefinitions vds
+  <> optempty directives ds
+  <> selectionSet ss
+node (AST.Node Nothing vds ds ss) =
+     optempty variableDefinitions vds
   <> optempty directives ds
   <> selectionSet ss
 

--- a/src/GraphQL/Internal/Syntax/Parser.hs
+++ b/src/GraphQL/Internal/Syntax/Parser.hs
@@ -52,7 +52,7 @@ operationDefinition =
   <?> "operationDefinition error!"
 
 node :: Parser AST.Node
-node = AST.Node <$> nameParser
+node = AST.Node <$> optempty nameParser
                 <*> optempty variableDefinitions
                 <*> optempty directives
                 <*> selectionSet

--- a/src/GraphQL/Internal/Syntax/Parser.hs
+++ b/src/GraphQL/Internal/Syntax/Parser.hs
@@ -52,7 +52,7 @@ operationDefinition =
   <?> "operationDefinition error!"
 
 node :: Parser AST.Node
-node = AST.Node <$> optempty nameParser
+node = AST.Node <$> optional nameParser
                 <*> optempty variableDefinitions
                 <*> optempty directives
                 <*> selectionSet

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -13,7 +13,7 @@ import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
 import GraphQL.Value (String(..))
-import GraphQL.Internal.Name (Name (Name), mempty)
+import GraphQL.Internal.Name (Name)
 import qualified GraphQL.Internal.Syntax.AST as AST
 import qualified GraphQL.Internal.Syntax.Parser as Parser
 import qualified GraphQL.Internal.Syntax.Encoder as Encoder
@@ -106,7 +106,7 @@ tests = testSpec "AST" $ do
       let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                        (AST.Query
-                         (AST.Node (Name mempty) [] []
+                         (AST.Node Nothing [] []
                            [ AST.SelectionField
                              (AST.Field Nothing dog [] []
                                [ AST.SelectionField (AST.Field Nothing someName [] [] [])
@@ -194,7 +194,7 @@ tests = testSpec "AST" $ do
       let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                          (AST.Query
-                           (AST.Node (Name mempty)
+                           (AST.Node Nothing
                             [ AST.VariableDefinition
                                 (AST.Variable "atOtherHomes")
                                 (AST.TypeNamed (AST.NamedType "Boolean"))

--- a/tests/ASTTests.hs
+++ b/tests/ASTTests.hs
@@ -121,7 +121,7 @@ tests = testSpec "AST" $ do
                          ])
                      , AST.DefinitionOperation
                        (AST.Query
-                        (AST.Node "getName" [] []
+                        (AST.Node (pure "getName") [] []
                          [ AST.SelectionField
                            (AST.Field Nothing dog [] []
                             [ AST.SelectionField
@@ -145,7 +145,7 @@ tests = testSpec "AST" $ do
       let expected = AST.QueryDocument
                      [ AST.DefinitionOperation
                          (AST.Query
-                           (AST.Node "houseTrainedQuery"
+                           (AST.Node (pure "houseTrainedQuery")
                             [ AST.VariableDefinition
                                 (AST.Variable "atOtherHomes")
                                 (AST.TypeNamed (AST.NamedType "Boolean"))

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -19,8 +19,8 @@ import GraphQL.Internal.Validation
   , getErrors
   )
 
-me :: Name
-me = "me"
+me :: Maybe Name
+me = pure "me"
 
 someName :: Name
 someName = "name"

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -10,7 +10,7 @@ import Test.QuickCheck ((===))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
-import GraphQL.Internal.Name (Name(Name), mempty)
+import GraphQL.Internal.Name (Name)
 import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.Schema (Schema)
 import GraphQL.Internal.Validation
@@ -52,7 +52,7 @@ tests = testSpec "Validation" $ do
       let doc = AST.QueryDocument
                 [ AST.DefinitionOperation
                   (AST.Query
-                    (AST.Node (Name mempty) [] []
+                    (AST.Node (Nothing) [] []
                       [ AST.SelectionField
                         (AST.Field Nothing dog [] []
                           [ AST.SelectionField (AST.Field Nothing someName [] [] [])
@@ -65,7 +65,7 @@ tests = testSpec "Validation" $ do
       let doc = AST.QueryDocument
                 [ AST.DefinitionOperation
                     (AST.Query
-                      (AST.Node (Name mempty)
+                      (AST.Node Nothing
                        [ AST.VariableDefinition
                            (AST.Variable "atOtherHomes")
                            (AST.TypeNamed (AST.NamedType "Boolean"))

--- a/tests/ValidationTests.hs
+++ b/tests/ValidationTests.hs
@@ -10,7 +10,7 @@ import Test.QuickCheck ((===))
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
-import GraphQL.Internal.Name (Name)
+import GraphQL.Internal.Name (Name(Name), mempty)
 import qualified GraphQL.Internal.Syntax.AST as AST
 import GraphQL.Internal.Schema (Schema)
 import GraphQL.Internal.Validation
@@ -24,6 +24,9 @@ me = pure "me"
 
 someName :: Name
 someName = "name"
+
+dog :: Name
+dog = "dog"
 
 -- | Schema used for these tests. Since none of them do type-level stuff, we
 -- don't need to define it.
@@ -42,6 +45,41 @@ tests = testSpec "Validation" $ do
                       ]
                     )
                   )
+                ]
+      getErrors schema doc `shouldBe` []
+
+    it "Treats anonymous queries as valid" $ do
+      let doc = AST.QueryDocument
+                [ AST.DefinitionOperation
+                  (AST.Query
+                    (AST.Node (Name mempty) [] []
+                      [ AST.SelectionField
+                        (AST.Field Nothing dog [] []
+                          [ AST.SelectionField (AST.Field Nothing someName [] [] [])
+                          ])
+                      ]))
+                ]
+      getErrors schema doc `shouldBe` []
+
+    it "Treats anonymous queries with variables as valid" $ do
+      let doc = AST.QueryDocument
+                [ AST.DefinitionOperation
+                    (AST.Query
+                      (AST.Node (Name mempty)
+                       [ AST.VariableDefinition
+                           (AST.Variable "atOtherHomes")
+                           (AST.TypeNamed (AST.NamedType "Boolean"))
+                           (Just (AST.ValueBoolean True))
+                       ] []
+                       [ AST.SelectionField
+                           (AST.Field Nothing dog [] []
+                            [ AST.SelectionField
+                                (AST.Field Nothing "isHousetrained"
+                                 [ AST.Argument "atOtherHomes"
+                                     (AST.ValueVariable (AST.Variable "atOtherHomes"))
+                                 ] [] [])
+                            ])
+                       ]))
                 ]
       getErrors schema doc `shouldBe` []
 


### PR DESCRIPTION
Add tests in ASTTests.hs:
- parses anonymous query documents
  - changed previous test of same name to: parses shorthand syntax documents
- parses anonymous query with variables
    
Added tests in ValidationTests.hs:
- Treats anonymous queries as valid
- Treats anonymous queries with variables as valid